### PR TITLE
Update button.js - to solve issue with State/Region field

### DIFF
--- a/view/frontend/web/js/paypal/button.js
+++ b/view/frontend/web/js/paypal/button.js
@@ -178,7 +178,7 @@ define(
                                             firstname: payload.details.firstName,
                                             lastname: payload.details.lastName,
                                             telephone: typeof address.phone !== 'undefined' ? address.phone : '',
-                                            region: typeof address.region !== 'undefined' ? address.region : ''
+                                            region: typeof address.state !== 'undefined' ? address.state : ''
                                         };
 
                                         formBuilder.build(


### PR DESCRIPTION
PayPal doesn't expect the State/Region field to be called "Region"... but instead uses "State" for this field!