### PR TITLE
fix phone number displaying by address

### DIFF
--- a/view/frontend/web/js/paypal/button.js
+++ b/view/frontend/web/js/paypal/button.js
@@ -177,7 +177,7 @@ define(
                                             email: payload.details.email,
                                             firstname: payload.details.firstName,
                                             lastname: payload.details.lastName,
-                                            telephone: typeof address.phone !== 'undefined' ? address.phone : '',
+                                            telephone: typeof payload.details.phone !== 'undefined' ? payload.details.phone : '',
                                             region: typeof address.region !== 'undefined' ? address.region : ''
                                         };
 


### PR DESCRIPTION
The string address.phone doesn't work ... but payload.details.phone does work.