### PR TITLE
Adding validation for Checkout Agreement

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/hosted-fields.js
+++ b/view/frontend/web/js/view/payment/method-renderer/hosted-fields.js
@@ -10,8 +10,9 @@ define([
     'Magento_Braintree/js/view/payment/method-renderer/cc-form',
     'Magento_Braintree/js/validator',
     'Magento_Vault/js/view/payment/vault-enabler',
+    'Magento_Checkout/js/model/payment/additional-validators',
     'mage/translate'
-], function ($, Component, validator, VaultEnabler, $t) {
+], function ($, Component, validator, VaultEnabler, additionalValidators, $t) {
     'use strict';
 
     return Component.extend({
@@ -188,7 +189,7 @@ define([
          * Trigger order placing
          */
         placeOrderClick: function () {
-            if (this.validateFormFields()) {
+            if (this.validateFormFields() && additionalValidators.validate()) {
                 this.placeOrder();
             }
         },


### PR DESCRIPTION
# Summary
There is an issue when a user tries to pay by credit card without agreeing to the terms and conditions.  This fixes it by adding using Magento's additional-validators to validate that the terms and conditions have been accepted before trying to open the 3D Secure window.

Follow the steps below to reproduce the error and if you make the file changes proposed above the issue should be fixed.

Note: I opened a support ticket on support.gene.co.uk, #9171.

# Preconditions
- Create a Terms and Conditions at Stores > Terms and Conditions
- Enable Terms and Conditions at Stores > Configuration > Sales > Checkout > Checkout Options.
- Enable 3D secure on Braintree module at Stores > Configuration > Payment Methods > Braintree > 3D Secure Verification Settings.

# Steps to Reproduce
- Add an item to the cart and proceed to the checkout as a guest user.
- Complete the shipping step.
- On Payment step select Credit Card (tmp - braintree test) and fill in credit card info
- Don't accept T&C's and try to place order
- Observe 3-d secure window and enter details, hitting "ok"
- See the error that T&C's are not accepted
- Accept T&C's and try to place order
- Observe "Please try to use another payment method" error