### PR TITLE
Update form.html

### DIFF
--- a/view/frontend/web/template/payment/form.html
+++ b/view/frontend/web/template/payment/form.html
@@ -136,9 +136,12 @@
                 <button class="action primary checkout"
                         type="submit"
                         data-bind="
-                        click: placeOrderClick,
-                        attr: {title: $t('Place Order')}
-                ">
+                            click: placeOrderClick,
+                            attr: {title: $t('Place Order')},
+                            css: {disabled: !isPlaceOrderActionAllowed()},
+                            enable: (getCode() == isChecked())"
+                        disbaled
+                >
                     <span data-bind="i18n: 'Place Order'"></span>
                 </button>
             </div>


### PR DESCRIPTION
Found an issue with the user being allowed to click the place order button even if they have not saved/selected a billing address.  I've only tested it with 3D secure enabled so it may only be occuring with that feature enabled.

Anyway, this PR simply adds the same approach Magento uses to disable the "Place Order" button if the user has no billing address saved/selected.

Below is how you can reproduce the issue before applying this fix.

### Preconditions
- Enable 3D secure on Braintree module at Stores > Configuration > Payment Methods > Braintree > 3D Secure Verification Settings.
### Steps to reproduce
1. Add any product to your cart and proceed to the checkout payment step.
1. Fill in the CC info.
1. Uncheck "My billing and shipping address are the same"  beneath the Billing Address title.
1. Fill in new address details.
1. Do not click the "Save" button beneath the address.
1. Click the "Place Order" button.
### Expected result
User should not be allowed to click "Place Order" button unless billing address is selected/saved.
### Actual result
Nothing happens in the browser window when the user clicks the "Place Order" button, but the console gives the following error: Uncaught TypeError: Cannot read property 'countryId' of null 3d-secure.js 1