### PR TITLE
BRAIN-48

### DIFF
--- a/Model/Config/Source/Layout.php
+++ b/Model/Config/Source/Layout.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Magento\Braintree\Model\Config\Source;
+
+/**
+ * Class Layout
+ * @package Magento\Braintree\Model\Config\Source
+ * @author Muj <muj@gene.co.uk>
+ */
+class Layout implements \Magento\Framework\Option\ArrayInterface
+{
+    /**
+     * Options getter
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return [
+            ['value' => 0, 'label' => __('Horizontal')],
+            ['value' => 1, 'label' => __('Vertical')],
+
+        ];
+    }
+
+    /**
+     * Get options in "key-value" format
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [0 => __('Horizontal'), 1 => __('Vertical')];
+    }
+}

--- a/Model/Config/Source/Size.php
+++ b/Model/Config/Source/Size.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Magento\Braintree\Model\Config\Source;
+
+/**
+ * Class Size
+ * @package Magento\Braintree\Model\Config\Source
+ * @author Muj <muj@gene.co.uk>
+ */
+class Size implements \Magento\Framework\Option\ArrayInterface
+{
+    /**
+     * Options getter
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return [
+            ['value' => 0, 'label' => __('Small')],
+            ['value' => 1, 'label' => __('Medium')],
+            ['value' => 2, 'label' => __('Large')],
+            ['value' => 3, 'label' => __('Responsive')]
+        ];
+    }
+
+    /**
+     * Get options in "key-value" format
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [0 => __('Small'), 1 => __('Medium'), 2 => __('Large'), 3 => __('Responsive')];
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -296,17 +296,131 @@
                             <config_path>payment/braintree_paypal/payee_email</config_path>
                             <comment>Consult Braintree Support before enabling this option.</comment>
                         </field>
-                        <field id="button_shape" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
-                            <label>Button Shape</label>
-                            <source_model>Magento\Braintree\Model\Config\Source\Shape</source_model>
-                            <config_path>payment/braintree_paypal/button_shape</config_path>
-                        </field>
+                        <group id="the_cart_page" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+                            <label>The Cart Page</label>
+                            <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
+                            <field id="button_display_cart"  translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+                                <label>Customisable</label>
+                                <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                                <config_path>payment/braintree_paypal/display_on_shopping_cart</config_path>
+                            </field>
+                            <field id="button_shape_cart" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+                                <label>Button Shape</label>
+                                <source_model>Magento\Braintree\Model\Config\Source\Shape</source_model>
+                                <config_path>payment/braintree_paypal/button_shape</config_path>
+                                <depends>
+                                    <field id="button_display_cart">1</field>
+                                </depends>
+                            </field>
+                            <field id="button_size_cart" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+                                <label>Button Size</label>
+                                <source_model>Magento\Braintree\Model\Config\Source\Size</source_model>
+                                <config_path>payment/braintree_paypal/button_size</config_path>
+                                <depends>
+                                    <field id="button_display_cart">1</field>
+                                </depends>
+                            </field>
+                            <field id="button_layout_cart" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+                                <label>Button Layout</label>
+                                <source_model>Magento\Braintree\Model\Config\Source\Layout</source_model>
+                                <config_path>payment/braintree_paypal/button_layout</config_path>
+                                <depends>
+                                    <field id="button_display_cart">1</field>
+                                </depends>
+                            </field>
+                            <field id="button_color_cart" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+                                <label>Button Color</label>
+                                <source_model>Magento\Braintree\Model\Config\Source\Color</source_model>
+                                <config_path>payment/braintree_paypal/button_color</config_path>
+                                <depends>
+                                    <field id="button_display_cart">1</field>
+                                </depends>
+                            </field>
+                        </group>
+                        <!--</group>-->
+                        <group id="mini_cart" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+                            <label>Mini Cart</label>
+                            <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
+                            <field id="button_display_minicart"  translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+                                <label>Customisable</label>
+                                <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                                <config_path>payment/braintree_paypal/display_on_shopping_cart</config_path>
+                            </field>
+                            <field id="button_shape_minicart" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+                                <label>Button Shape</label>
+                                <source_model>Magento\Braintree\Model\Config\Source\Shape</source_model>
+                                <config_path>payment/braintree_paypal/button_shape</config_path>
+                                <depends>
+                                    <field id="button_display_minicart">1</field>
+                                </depends>
+                            </field>
+                            <field id="button_size_minicart" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+                                <label>Button Size</label>
+                                <source_model>Magento\Braintree\Model\Config\Source\Size</source_model>
+                                <config_path>payment/braintree_paypal/button_size</config_path>
+                                <depends>
+                                    <field id="button_display_minicart">1</field>
+                                </depends>
+                            </field>
+                            <field id="button_layout_minicart" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+                                <label>Button Layout</label>
+                                <source_model>Magento\Braintree\Model\Config\Source\Layout</source_model>
+                                <config_path>payment/braintree_paypal/button_layout</config_path>
+                                <depends>
+                                    <field id="button_display_minicart">1</field>
+                                </depends>
+                            </field>
+                            <field id="button_color_minicart" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+                                <label>Button Color</label>
+                                <source_model>Magento\Braintree\Model\Config\Source\Color</source_model>
+                                <config_path>payment/braintree_paypal/button_color</config_path>
+                                <depends>
+                                    <field id="button_display_minicart">1</field>
+                                </depends>
+                            </field>
+                        </group>
 
-                        <field id="button_color" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
-                            <label>Button Color</label>
-                            <source_model>Magento\Braintree\Model\Config\Source\Color</source_model>
-                            <config_path>payment/braintree_paypal/button_color</config_path>
-                        </field>
+                        <group id="checkout_page" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+                            <label>Checkout Page</label>
+                            <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
+                            <field id="button_display_checkout"  translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+                                <label>Customisable</label>
+                                <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                                <config_path>payment/braintree_paypal/display_on_shopping_cart</config_path>
+                            </field>
+                            <field id="button_shape_checkout" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+                                <label>Button Shape</label>
+                                <source_model>Magento\Braintree\Model\Config\Source\Shape</source_model>
+                                <config_path>payment/braintree_paypal/button_shape</config_path>
+                                <depends>
+                                    <field id="button_display_checkout">1</field>
+                                </depends>
+                            </field>
+                            <field id="button_size_chekout" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+                                <label>Button Size</label>
+                                <source_model>Magento\Braintree\Model\Config\Source\Size</source_model>
+                                <config_path>payment/braintree_paypal/button_size</config_path>
+                                <depends>
+                                    <field id="button_display_checkout">1</field>
+                                </depends>
+                            </field>
+                            <field id="button_layout_checkout" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+                                <label>Button Layout</label>
+                                <source_model>Magento\Braintree\Model\Config\Source\Layout</source_model>
+                                <config_path>payment/braintree_paypal/button_layout</config_path>
+                                <depends>
+                                    <field id="button_display_checkout">1</field>
+                                </depends>
+                            </field>
+                            <field id="button_color_checkout" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+                                <label>Button Color</label>
+                                <source_model>Magento\Braintree\Model\Config\Source\Color</source_model>
+                                <config_path>payment/braintree_paypal/button_color</config_path>
+                                <depends>
+                                    <field id="button_display_checkout">1</field>
+                                </depends>
+                            </field>
+                        </group>
                     </group>
                     <group id="braintree_paypal_credit" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="40">
                         <label>PayPal Credit through Braintree</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -50,7 +50,7 @@
                 <require_billing_address>0</require_billing_address>
                 <allow_shipping_address_override>1</allow_shipping_address_override>
                 <display_on_shopping_cart>1</display_on_shopping_cart>
-                <order_status>processing</order_status>
+                <order_starttus>processing</order_starttus>
                 <is_gateway>1</is_gateway>
                 <can_use_checkout>1</can_use_checkout>
                 <can_authorize>1</can_authorize>
@@ -59,12 +59,20 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_void>1</can_void>
-                <can_cancel>1</can_cancel>
-                <can_authorize_vault>1</can_authorize_vault>
+                <can_cancel>1</can_cancel><can_authorize_vault>1</can_authorize_vault>
                 <can_capture_vault>1</can_capture_vault>
                 <privateInfoKeys>processorResponseCode,processorResponseText,paymentId</privateInfoKeys>
                 <paymentInfoKeys>processorResponseCode,processorResponseText,paymentId,payerEmail</paymentInfoKeys>
                 <sort_order>1</sort_order>
+                <the_cart_page>
+                    <button_display_cart>0</button_display_cart>
+                </the_cart_page>
+                <mini_cart>
+                    <button_display_minicart>0</button_display_minicart>
+                </mini_cart>
+                <checkout_page>
+                    <button_display_checkout>0</button_display_checkout>
+                </checkout_page>
             </braintree_paypal>
             <braintree_paypal_credit>
                 <model>BraintreePayPalCreditFacade</model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -50,7 +50,7 @@
                 <require_billing_address>0</require_billing_address>
                 <allow_shipping_address_override>1</allow_shipping_address_override>
                 <display_on_shopping_cart>1</display_on_shopping_cart>
-                <order_starttus>processing</order_starttus>
+                <order_status>processing</order_status>
                 <is_gateway>1</is_gateway>
                 <can_use_checkout>1</can_use_checkout>
                 <can_authorize>1</can_authorize>


### PR DESCRIPTION
BRAIN-48
Colour
Shape
Size
Layout
There should be three sections in the MAgento 2 admin (as there is in the M1 admin) to set these options for three different locations. These locations are

The mini-cart
The cart page
The checkout page
The options should use the same default options as the Magento 1 module.
Please ignore the Product Page, as this is not functionality supported by the M2 module.