### PR TITLE
https://genecommerce.atlassian.net/browse/BRAIN-50

### DIFF
--- a/view/frontend/templates/paypal/button.phtml
+++ b/view/frontend/templates/paypal/button.phtml
@@ -8,7 +8,7 @@
  * @var \Magento\Braintree\Block\Paypal\Button $block
  */
 
-
+//$id = $block->isCreditActive() ? $block->getContainerId() . "_credit" . mt_rand() :  $block->getContainerId() . mt_rand();
 $id = $block->getContainerId() . mt_rand();
 $config = [
     'Magento_Braintree/js/paypal/button' => [
@@ -17,20 +17,21 @@ $config = [
         'clientToken' => $block->getClientToken(),
         'displayName' => $block->getMerchantName(),
         'payeeEmail' => $block->getPayeeEmail(),
-        'color' => $block->getButtonColor(),
+//        'color' => $block->getButtonColor(),
+        'label' => 'checkout ',
         'shape' => $block->getButtonShape(),
-        'actionSuccess' => $block->getActionSuccess()
+        'size'  => $block->getButtonSize(),
+        //'layout'  => $block->getButtonLayout(),
+        //'color'  => $block->getButtonColor(),
+        'actionSuccess' => $block->getActionSuccess(),
+        'offerCredit' => true
+        //'offerCredit' => false
+        //'offerCredit' => $block->isCreditActive() == true ? true : false
     ]
 ];
-
-$creditId = $block->getContainerId() . "_credit" . mt_rand();
-$configCredit = $config;
-$configCredit['Magento_Braintree/js/paypal/button']['id'] = $creditId;
-$configCredit['Magento_Braintree/js/paypal/button']['offerCredit'] = true;
 ?>
-
 <div data-mage-init='<?php /* @noEscape */ echo json_encode($config); ?>'
-     class="paypal checkout paypal-logo braintree-paypal-logo<?php
+     class="paypal checkout paypal-logo braintree-paypal-logo <?php
      /* @noEscape */ echo $block->getContainerId(); ?>-container">
     <div data-currency="<?php /* @noEscape */ echo $block->getCurrency(); ?>"
          data-locale="<?php /* @noEscape */ echo $block->getLocale(); ?>"
@@ -38,15 +39,3 @@ $configCredit['Magento_Braintree/js/paypal/button']['offerCredit'] = true;
          id="<?php /* @noEscape */ echo $id; ?>"
          class="action-braintree-paypal-logo"></div>
 </div>
-
-<?php if ($block->isCreditActive()) : ?>
-    <div data-mage-init='<?php /* @noEscape */ echo json_encode($configCredit); ?>'
-         class="paypal checkout paypal-logo braintree-paypal-logo<?php
-         /* @noEscape */ echo $block->getContainerId(); ?>-container">
-        <div data-currency="<?php /* @noEscape */ echo $block->getCurrency(); ?>"
-             data-locale="<?php /* @noEscape */ echo $block->getLocale(); ?>"
-             data-amount="<?php /* @noEscape */ echo $block->getAmount(); ?>"
-             id="<?php /* @noEscape */ echo $creditId; ?>"
-             class="action-braintree-paypal-logo"></div>
-    </div>
-<?php endif; ?>

--- a/view/frontend/web/js/paypal/button.js
+++ b/view/frontend/web/js/paypal/button.js
@@ -84,8 +84,8 @@ define(
              * @returns {Object}
              */
             initComponent: function () {
-                console.log('credit');
-                console.log(this.offerCredit);
+                //console.log('credit');
+                //console.log(this.offerCredit);
                 var $this = $('#' + this.id),
                     data = {
                         amount: $this.data('amount'),
@@ -134,17 +134,17 @@ define(
                             shape: this.shape,
                         };
                         var funding = {};
-                        if (this.offerCredit === true) {
-                            //  console.log('went into if');
+                        if (this.offerCredit) {
+                          //  console.log('went into if');
 
                             //style = {
-                            funding =  {
-                                allowed: [paypal.FUNDING.CREDIT ]
-                            };
+                                funding =  {
+                                    allowed: [paypal.FUNDING.CREDIT ]
+                                };
 
                             // };
                         }
-                        console.log(funding);
+                        //console.log(funding);
                         var actionSuccess = this.actionSuccess;
                         paypal.Button.render({
                             env: this.environment,

--- a/view/frontend/web/js/paypal/button.js
+++ b/view/frontend/web/js/paypal/button.js
@@ -28,7 +28,6 @@ define(
         formBuilder
     ) {
         'use strict';
-
         return Component.extend({
 
             defaults: {
@@ -85,6 +84,8 @@ define(
              * @returns {Object}
              */
             initComponent: function () {
+                console.log('credit');
+                console.log(this.offerCredit);
                 var $this = $('#' + this.id),
                     data = {
                         amount: $this.data('amount'),
@@ -128,26 +129,30 @@ define(
                             console.error('paypalCheckout instantiation error', createErr);
                             return;
                         }
-
                         var style = {
                             color: this.color,
-                            shape: this.shape
+                            shape: this.shape,
                         };
+                        var funding = {};
                         if (this.offerCredit === true) {
-                            style = {
-                                label: 'credit'
-                            };
-                        }
+                            //  console.log('went into if');
 
+                            //style = {
+                            funding =  {
+                                allowed: [paypal.FUNDING.CREDIT ]
+                            };
+
+                            // };
+                        }
+                        console.log(funding);
                         var actionSuccess = this.actionSuccess;
                         paypal.Button.render({
                             env: this.environment,
                             style: style,
-
+                            funding: funding,
                             payment: function () {
                                 return paypalCheckoutInstance.createPayment(data);
                             },
-
                             onCancel: function (data) {
                                 jQuery("#maincontent").trigger('processStop');
                             },
@@ -156,7 +161,6 @@ define(
                                 console.error('paypalCheckout button render error', err);
                                 jQuery("#maincontent").trigger('processStop');
                             },
-
                             /**
                              * Pass the payload (and payload.nonce) through to the implementation's onPaymentMethodReceived method
                              * @param data
@@ -180,7 +184,6 @@ define(
                                             telephone: typeof payload.details.phone !== 'undefined' ? payload.details.phone : '',
                                             region: typeof address.state !== 'undefined' ? address.state : ''
                                         };
-
                                         formBuilder.build(
                                             {
                                                 action: actionSuccess,


### PR DESCRIPTION
1. Remove the PayPal credit code from the referenced template
https://github.com/genecommerce/module-braintree/blob/master/view/frontend/templates/paypal/button.phtml
2. Modify the $config array to only set "offerCredit" to "true" when if( $block->isCreditActive() == true)
See line 29 in the template for the node structure of "offerCredit"

Scenario 1 to test
1. Enable PayPal Credit in the magento admin
2. Add something to your cart
3. You should only see one div in the mini-cart with the class of "braintree-paypal-logo"
4. You should see the normal PayPal button in the mini cart
5. You should see the PayPal Credit button in the mini cart
test Pass
Scenario 2 to test
1. Disable PayPal Credit in the magento admin
2. Add something to your cart
3. You should only see one div in the mini-cart with the class of "braintree-paypal-logo"
4. You should only see the normal PayPal button in the mini cart
5. You should NOT see the PayPal credit button in the mini cart
test fail