### PR TITLE
Fixed issue with PayPal Credit sandbox check

### DIFF
--- a/Gateway/Config/PayPalCredit/Config.php
+++ b/Gateway/Config/PayPalCredit/Config.php
@@ -163,7 +163,7 @@ class Config implements ConfigInterface
      */
     public function getSandbox()
     {
-        return (bool) $this->getConfigValue('payment/braintree/environment') == 'sandbox';
+        return $this->getConfigValue('payment/braintree/environment') === 'sandbox';
     }
 
     /**


### PR DESCRIPTION
Found issue where running the PayPal Credit Price cron in Braintree Production Environment would always return the PayPal sandbox url in https://github.com/genecommerce/module-braintree-magento2/blob/master/Gateway/Config/PayPalCredit/Config.php#L164

### Preconditions
* Enable Production mode in Braintree settings

### Steps to reproduce
1. Run the Braintree PayPal Credit Cron in Braintree Production mode

### Expected result
PayPal Credit prices get updated and cron finishes with no exceptions

### Actual result
`[Exception]
 Unable to retrieve PayPal API token. Error returned with request to https://api.sandbox.paypal.com/v1/oauth2/token. Error: invalid_client`

### Possible Fix
The original code
`return (bool) $this->getConfigValue('payment/braintree/environment') == 'sandbox';`
PHP would run the typecast to the string first for example 
`(bool) $this->getConfigValue('payment/braintree/environment')` 
that would be true. Then running 
`true == 'sandbox'` 
would also be true so no matter what the config value is it would always return true

I added a fix to remove the typecast as it will always return bool and added a Identical check instead of a Equal check