### PR TITLE
Exclude Pay.js From Minify

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -7,6 +7,13 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
+        <dev>
+            <js>
+                <minify_exclude>
+                    pay.js
+                </minify_exclude>
+            </js>
+        </dev>
         <payment>
             <braintree>
                 <model>BraintreeFacade</model>


### PR DESCRIPTION
Related to magento/magento2#5835 and MAGETWO-62713

When Using Magento's Minify feature:
**Steps to reproduce**
Login to Backend
Shops -> Configuration ->Advanced -> Developer -> JavaScript Settings
Put "Minify JavaScript Files" to "Yes"
Save Config

**Solution**
adding minify_exclude removes this file from being minified.
Without this fix the google pay file url will be https://pay.google.com/gp/p/js/pay.min.js
With the Fix the url will always be https://pay.google.com/gp/p/js/pay.js regardless of the Minify Setting.