### PR TITLE
Add class names to payment methods

### DIFF
--- a/view/frontend/web/template/applepay/core-checkout.html
+++ b/view/frontend/web/template/applepay/core-checkout.html
@@ -1,5 +1,5 @@
 <!-- ko if: deviceSupported -->
-<div class="payment-method" data-bind="css: {'_active': (getCode() == isChecked())}">
+<div class="payment-method payment-method-braintree-applepay" data-bind="css: {'_active': (getCode() == isChecked())}">
     <div class="payment-method-title field choice">
         <input type="radio"
                name="payment[method]"

--- a/view/frontend/web/template/googlepay/core-checkout.html
+++ b/view/frontend/web/template/googlepay/core-checkout.html
@@ -1,5 +1,5 @@
 <!-- ko if: deviceSupported -->
-<div class="payment-method" data-bind="css: {'_active': (getCode() == isChecked())}">
+<div class="payment-method payment-method-braintree-googlepay" data-bind="css: {'_active': (getCode() == isChecked())}">
     <div class="payment-method-title field choice">
         <input type="radio"
                name="payment[method]"

--- a/view/frontend/web/template/payment/cc/vault.html
+++ b/view/frontend/web/template/payment/cc/vault.html
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<div class="payment-method" css="'_active': (getId() === isChecked())">
+<div class="payment-method payment-method-braintree-cc-vault" css="'_active': (getId() === isChecked())">
     <div class="payment-method-title field choice">
         <input type="radio"
                name="payment[method]"

--- a/view/frontend/web/template/payment/paypal-credit.html
+++ b/view/frontend/web/template/payment/paypal-credit.html
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<div class="payment-method" data-bind="css: {'_active': isActive()}">
+<div class="payment-method payment-method-braintree-paypal-credit" data-bind="css: {'_active': isActive()}">
     <div class="payment-method-title field choice">
         <input type="radio"
                name="payment[method]"

--- a/view/frontend/web/template/payment/paypal.html
+++ b/view/frontend/web/template/payment/paypal.html
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<div class="payment-method" data-bind="css: {'_active': isActive()}">
+<div class="payment-method payment-method-braintree-paypal" data-bind="css: {'_active': isActive()}">
     <div class="payment-method-title field choice">
         <input type="radio"
                name="payment[method]"

--- a/view/frontend/web/template/payment/paypal/vault.html
+++ b/view/frontend/web/template/payment/paypal/vault.html
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<div class="payment-method" css="'_active': (getId() === isChecked())">
+<div class="payment-method payment-method-braintree-paypal-vault" css="'_active': (getId() === isChecked())">
     <div class="payment-method-title field choice">
         <input type="radio"
                name="payment[method]"


### PR DESCRIPTION
### Summary

Currently there is no simple way for designers to customise the payment methods with CSS in the checkout as there is no unique class names for each different payment method in Braintree due to this we need to extend the html templates to just add a class names.

### Solution

Added class names to the payment method types to allow for custom CSS styles to be applied to the  payment methods