### PR TITLE
Add config check for PayPal and PayPal Credit

### DIFF
--- a/Gateway/Config/PayPalCredit/Config.php
+++ b/Gateway/Config/PayPalCredit/Config.php
@@ -113,6 +113,14 @@ class Config implements ConfigInterface
      */
     public function isActive()
     {
+        $paypalActive = $this->getConfigValue("payment/braintree_paypal/active");
+        $paypalCreditActive = $this->getConfigValue("payment/braintree_paypal_credit/active");
+
+        // If PayPal or PayPal Credit is disabled in the admin
+        if (!$paypalActive || !$paypalCreditActive) {
+            return false;
+        }
+
         // Only allowed on US and UK
         if (!$this->isUk() && !$this->isUS()) {
             return false;


### PR DESCRIPTION
Found issue where if the `Merchant Name` config is set and the store is set to UK/US that PayPal Credit would display in the cart even though the config value for `Enable PayPal through Braintree` and `Enable PayPal Credit through Braintree` are both set to `No`.

This is an issue for developers that use development configuration setup scripts as PayPal credit would show as enabled even though the config value `Enable PayPal Credit through Braintree` is set to `No`

### Preconditions
* Config values for `PayPal Credit through Braintree` are setup

### Steps to reproduce
1. View a page that contains PayPal Credit e.g the Cart page

### Expected result
If `Enable PayPal Credit through Braintree` is set to `No` then PayPal credit Calculator should not be rendered on the Cart page

### Actual result
PayPal Credit calculator is rendered on the cart page and the `Enable PayPal Credit through Braintree` config value is ignored

### Possible Fix
Added a config check within https://github.com/genecommerce/module-braintree-magento2/blob/a2eda6025a4f5dc59aa385a8815a9a7157d691ec/Gateway/Config/PayPalCredit/Config.php#L114 that checks if any of the `Enable PayPal through Braintree` and `Enable PayPal Credit through Braintree` are set to `No` if so returns false