### PR TITLE
PayPal Credit Price Rule Issue

### DIFF
--- a/Api/CreditPriceRepositoryInterface.php
+++ b/Api/CreditPriceRepositoryInterface.php
@@ -20,19 +20,22 @@ interface CreditPriceRepositoryInterface
 
     /**
      * @param int $productId
+     * @param int $websiteId
      * @return CreditPriceDataInterface
      */
-    public function getByProductId($productId);
+    public function getByProductId($productId, $websiteId = 0);
 
     /**
      * @param $productId
+     * @param int $websiteId
      * @return Data\CreditPriceDataInterface
      */
-    public function getCheapestByProductId($productId);
+    public function getCheapestByProductId($productId, $websiteId = 0);
 
     /**
      * @param int $productId
+     * @param int $websiteId
      * @return mixed
      */
-    public function deleteByProductId($productId);
+    public function deleteByProductId($productId, $websiteId = 0);
 }

--- a/Api/Data/CreditPriceDataInterface.php
+++ b/Api/Data/CreditPriceDataInterface.php
@@ -17,6 +17,7 @@ interface CreditPriceDataInterface
     const INSTALMENT_RATE = 'instalment_rate';
     const COST_OF_PURCHASE = 'cost_of_purchase';
     const TOTAL_INC_INTEREST = 'total_inc_interest';
+    const WEBSITE_ID = 'website_id';
 
     /**
      * @return int
@@ -94,4 +95,15 @@ interface CreditPriceDataInterface
      * @return CreditPriceDataInterface
      */
     public function setTotalIncInterest($value);
+
+    /**
+     * @return int
+     */
+    public function getWebsiteId();
+
+    /**
+     * @param int $value
+     * @return CreditPriceDataInterface
+     */
+    public function setWebsiteId($value);
 }

--- a/Block/Credit/Calculator/Listing/Product.php
+++ b/Block/Credit/Calculator/Listing/Product.php
@@ -84,7 +84,10 @@ class Product extends Template
      */
     public function getPriceData()
     {
-        $data = $this->creditPriceRepository->getCheapestByProductId($this->getProduct()->getId());
+        $productId = $this->getProduct()->getId();
+        $websiteId = $this->_storeManager->getStore()->getWebsiteId();
+
+        $data = $this->creditPriceRepository->getCheapestByProductId($productId, $websiteId);
         if ($data->getId()) {
             return $data;
         }

--- a/Block/Credit/Calculator/Product/View.php
+++ b/Block/Credit/Calculator/Product/View.php
@@ -75,7 +75,10 @@ class View extends Template
     public function getPriceData()
     {
         if ($this->getProduct()) {
-            $results = $this->creditPriceRepository->getByProductId($this->getProduct()->getId());
+            $productId = $this->getProduct()->getId();
+            $websiteId = $this->_storeManager->getStore()->getWebsiteId();
+
+            $results = $this->creditPriceRepository->getByProductId($productId, $websiteId);
             if (!empty($results)) {
                 $options = [];
                 foreach ($results as $option) {

--- a/Cron/CreditPrice.php
+++ b/Cron/CreditPrice.php
@@ -109,6 +109,11 @@ class CreditPrice
                 continue;
             }
 
+            $websiteId = $website->getId();
+            $defaultStore = $website->getDefaultGroup()->getDefaultStore()->getId();
+
+            $this->storeManager->setCurrentStore($defaultStore);
+
             // Retrieve paginated collection of product and their price
             $collection = $this->productCollection->create();
             $collection->addAttributeToSelect('price')

--- a/Cron/CreditPrice.php
+++ b/Cron/CreditPrice.php
@@ -112,6 +112,7 @@ class CreditPrice
             $websiteId = $website->getId();
             $defaultStore = $website->getDefaultGroup()->getDefaultStore()->getId();
 
+            // Set current store to allow for store specific catalog price rules to be applied
             $this->storeManager->setCurrentStore($defaultStore);
 
             // Retrieve paginated collection of product and their price
@@ -130,6 +131,7 @@ class CreditPrice
                         // Delete by product_id
                         $this->creditPriceRepository->deleteByProductId($product->getId(), $websiteId);
 
+                        // Get product price including any catalog price rules or discounts
                         $productPrice = $product->getPriceInfo()->getPrice('final_price')->getAmount()->getValue();
 
                         // Retrieve data from PayPal

--- a/Cron/CreditPrice.php
+++ b/Cron/CreditPrice.php
@@ -105,6 +105,10 @@ class CreditPrice
 
         /* @var Website $website */
         foreach ($this->getWebsites() as $website) {
+            if (!$website->getDefaultGroup() || !$website->getDefaultGroup()->getDefaultStore()) {
+                continue;
+            }
+
             // Retrieve paginated collection of product and their price
             $collection = $this->productCollection->create();
             $collection->addAttributeToSelect('price')

--- a/Cron/CreditPrice.php
+++ b/Cron/CreditPrice.php
@@ -128,7 +128,7 @@ class CreditPrice
                 foreach ($collection as $product) {
                     try {
                         // Delete by product_id
-                        $this->creditPriceRepository->deleteByProductId($product->getId());
+                        $this->creditPriceRepository->deleteByProductId($product->getId(), $websiteId);
 
                         $productPrice = $product->getPriceInfo()->getPrice('final_price')->getAmount()->getValue();
 

--- a/Cron/CreditPrice.php
+++ b/Cron/CreditPrice.php
@@ -129,8 +129,10 @@ class CreditPrice
                         // Delete by product_id
                         $this->creditPriceRepository->deleteByProductId($product->getId());
 
+                        $productPrice = $product->getPriceInfo()->getPrice('final_price')->getAmount()->getValue();
+
                         // Retrieve data from PayPal
-                        $priceOptions = $this->creditApi->getPriceOptions($product->getFinalPrice());
+                        $priceOptions = $this->creditApi->getPriceOptions($productPrice);
                         foreach ($priceOptions as $priceOption) {
                             // Populate model
                             /** @var $model \Magento\Braintree\Api\Data\CreditPriceDataInterface */

--- a/Cron/CreditPrice.php
+++ b/Cron/CreditPrice.php
@@ -117,6 +117,7 @@ class CreditPrice
             // Retrieve paginated collection of product and their price
             $collection = $this->productCollection->create();
             $collection->addAttributeToSelect('price')
+                ->addWebsiteFilter($websiteId)
                 ->setPageSize(100);
 
             $lastPage = $collection->getLastPageNumber();
@@ -143,6 +144,7 @@ class CreditPrice
                             $model->setInstalmentRate($priceOption['instalment_rate']);
                             $model->setCostOfPurchase($priceOption['cost_of_purchase']);
                             $model->setTotalIncInterest($priceOption['total_inc_interest']);
+                            $model->setWebsiteId($websiteId);
 
                             $this->creditPriceRepository->save($model);
                         }

--- a/Model/CreditPrice.php
+++ b/Model/CreditPrice.php
@@ -80,6 +80,14 @@ class CreditPrice extends AbstractModel implements CreditPriceDataInterface
     /**
      * @inheritdoc
      */
+    public function getWebsiteId()
+    {
+        return $this->getData(self::WEBSITE_ID);
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function setId($value)
     {
         return $this->setData(self::ID, $value);
@@ -131,5 +139,13 @@ class CreditPrice extends AbstractModel implements CreditPriceDataInterface
     public function setTotalIncInterest($value)
     {
         return $this->setData(self::TOTAL_INC_INTEREST, $value);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setWebsiteId($value)
+    {
+        return $this->setData(self::WEBSITE_ID, $value);
     }
 }

--- a/Model/ResourceModel/CreditPriceRepository.php
+++ b/Model/ResourceModel/CreditPriceRepository.php
@@ -38,11 +38,12 @@ class CreditPriceRepository implements CreditPriceRepositoryInterface
     /**
      * @inheritdoc
      */
-    public function getByProductId($productId)
+    public function getByProductId($productId, $websiteId = 0)
     {
         /** @var CreditPrice\Collection $collection */
         $collection = $this->collectionFactory->create();
         $collection->addFieldToFilter('product_id', $productId);
+        $collection->addFieldToFilter('website_id', $websiteId);
         $collection->setOrder('term', \Magento\Framework\Data\Collection\AbstractDb::SORT_ORDER_ASC);
         return $collection->getItems();
     }
@@ -50,11 +51,12 @@ class CreditPriceRepository implements CreditPriceRepositoryInterface
     /**
      * @inheritdoc
      */
-    public function getCheapestByProductId($productId)
+    public function getCheapestByProductId($productId, $websiteId = 0)
     {
         /** @var CreditPrice\Collection $collection */
         $collection = $this->collectionFactory->create();
         $collection->addFieldToFilter('product_id', $productId);
+        $collection->addFieldToFilter('website_id', $websiteId);
         $collection->setOrder('monthly_payment', \Magento\Framework\Data\Collection\AbstractDb::SORT_ORDER_ASC);
         $collection->setPageSize(1);
 
@@ -64,10 +66,11 @@ class CreditPriceRepository implements CreditPriceRepositoryInterface
     /**
      * @inheritdoc
      */
-    public function deleteByProductId($productId)
+    public function deleteByProductId($productId, $websiteId = 0)
     {
         $collection = $this->collectionFactory->create();
         $collection->addFieldToFilter('product_id', $productId);
+        $collection->addFieldToFilter('website_id', $websiteId);
         return $collection->walk('delete');
     }
 }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -27,6 +27,11 @@ class UpgradeSchema implements UpgradeSchemaInterface
             $this->braintreeCreditPrices($installer);
         }
 
+        // 3.1.0
+        if (version_compare($context->getVersion(), '3.1.0', '<')) {
+            $this->braintreeAddWebsiteFieldToCreditPrices($installer);
+        }
+
         $installer->endSetup();
     }
 
@@ -149,5 +154,24 @@ class UpgradeSchema implements UpgradeSchemaInterface
             )
             ->setComment('Braintree credit rates');
         $installer->getConnection()->createTable($table);
+    }
+
+    /**
+     * Add website_id field to the braintree_credit_prices table
+     * @param SchemaSetupInterface $installer
+     */
+    private function braintreeAddWebsiteFieldToCreditPrices(SchemaSetupInterface $installer)
+    {
+        $installer->getConnection()->addColumn(
+            $installer->getTable('braintree_credit_prices'),
+            'website_id',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
+                'size' => null,
+                'nullable' => false,
+                'unsigned' => true,
+                'comment' => 'Website Id'
+            ]
+        );
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "gene/module-braintree",
     "description": "Fork from the Magento Braintree 2.2.0 module by Gene Commerce for PayPal.",
-    "version": "3.0.8",
+    "version": "3.1.0",
     "require": {
         "magento/module-config": "101.0.*|101.1.*",
         "magento/module-directory": "100.2.*|100.3.*",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "gene/module-braintree",
     "description": "Fork from the Magento Braintree 2.2.0 module by Gene Commerce for PayPal.",
-    "version": "3.1.0",
+    "version": "3.0.8",
     "require": {
         "magento/module-config": "101.0.*|101.1.*",
         "magento/module-directory": "100.2.*|100.3.*",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Braintree" setup_version="3.0.8">
+    <module name="Magento_Braintree" setup_version="3.1.0">
         <sequence>
             <module name="Magento_Customer"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
Found an issue where if there is a catalog price rule set on a product the cron will still send the original product price that is set in the admin without applying the catalog price rule. This causes confusion to customers where the PayPal Credit prices do not reflect on what is being shown to customers on the frontend.

### Preconditions
* PayPal Credit is setup with sandbox or live credentials
* PayPal Credit cron is enabled and running

### Steps to reproduce
1. Create a Catalog Price Rule and apply the rule to a targeted product
2. Run the PayPal Credit cron

### Expected result
The discount should be applied to the product price before it is sent off to PayPal to calculate the credit prices.

### Actual result
The discount is not applied and the original admin value of the product price is sent thus the returned data from PayPal is not correct.

### Possible Fix
By reviewing how Magento deals with this issue with this issue in the price alert module I have changed the `braintree_credit_prices` schema to now include the website id.

This will now allow for the cron to loop over each website and fetch the default store view as prices are calculated based on website not store view. 

By getting the default store view it will set the current store then fetch the product price by having a store view that is not admin this will now fetch the product price that now includes the catalog price rules and other discounts applied.