### PR TITLE
Add second address line on PayPal button componenet

### DIFF
--- a/view/frontend/web/js/paypal/button.js
+++ b/view/frontend/web/js/paypal/button.js
@@ -273,7 +273,7 @@ define(
                                         // Map the shipping address correctly
                                         var address = payload.details.shippingAddress;
                                         payload.details.shippingAddress = {
-                                            streetAddress: address.line1,
+                                            streetAddress: typeof address.line2 !== 'undefined' ? address.line1 + " " + address.line2 : address.line1,
                                             locality: address.city,
                                             postalCode: address.postalCode,
                                             countryCodeAlpha2: address.countryCode,


### PR DESCRIPTION
Without this change all the PayPal transactions are not returning the second address line.