### PR TITLE
guest quote id for apple pay - No such entity with cartId = [] []

### DIFF
--- a/view/frontend/templates/applepay/shortcut.phtml
+++ b/view/frontend/templates/applepay/shortcut.phtml
@@ -14,7 +14,6 @@ $config = [
     "Magento_Braintree/js/applepay/implementations/shortcut" => [
         'id' => $id,
         'clientToken' => $block->getClientToken(),
-        'quoteId' => $block->getQuoteId(),
         'displayName' => $block->getMerchantName(),
         'actionSuccess' => $block->getActionSuccess(),
         'grandTotalAmount' => $block->getAmount(),


### PR DESCRIPTION
error - main.CRITICAL: No such entity with cartId = [] []

Replicate :
* enable production mode
* enable apple pay payment
* go on frontend and navigate around as a guest
* see error in system.log file