### PR TITLE
fix table prefix for quote address error

### DIFF
--- a/Model/Paypal/Helper/QuoteUpdater.php
+++ b/Model/Paypal/Helper/QuoteUpdater.php
@@ -123,7 +123,7 @@ class QuoteUpdater extends AbstractHelper
     private function cleanUpAddress(Quote $quote)
     {
         $this->addressFactory->getConnection()->delete(
-            'quote_address',
+			$quote->getResource()->getTable('quote_address'),
             'quote_id = ' . (int) $quote->getId() . ' AND email IS NULL'
         );
     }


### PR DESCRIPTION
Fix exception when using table prefix : 
Exception message: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'magento231.quote_address' doesn't exist