### PR TITLE
Fix broken Magento's Swagger due to Magento2 coding standards

### DIFF
--- a/Api/AuthInterface.php
+++ b/Api/AuthInterface.php
@@ -13,7 +13,7 @@ interface AuthInterface
 {
     /**
      * Returns details required to be able to submit a payment with apple pay.
-     * @return AuthDataInterface
+     * @return \Magento\Braintree\Api\Data\AuthDataInterface
      */
     public function get(): AuthDataInterface;
 }

--- a/Api/CreditPriceRepositoryInterface.php
+++ b/Api/CreditPriceRepositoryInterface.php
@@ -14,26 +14,26 @@ use Magento\Framework\DataObject;
 interface CreditPriceRepositoryInterface
 {
     /**
-     * @param CreditPriceDataInterface $entity
-     * @return CreditPriceDataInterface
+     * @param \Magento\Braintree\Api\Data\CreditPriceDataInterface $entity
+     * @return \Magento\Braintree\Api\Data\CreditPriceDataInterface
      */
     public function save(CreditPriceDataInterface $entity): CreditPriceDataInterface;
 
     /**
      * @param int $productId
-     * @return CreditPriceDataInterface
+     * @return \Magento\Braintree\Api\Data\CreditPriceDataInterface
      */
     public function getByProductId($productId);
 
     /**
      * @param $productId
-     * @return Data\CreditPriceDataInterface|DataObject
+     * @return \Magento\Braintree\Api\Data\CreditPriceDataInterface|\Magento\Framework\DataObject
      */
     public function getCheapestByProductId($productId);
 
     /**
      * @param int $productId
-     * @return mixed
+     * @return \Magento\Braintree\Api\Data\CreditPriceDataInterface[]
      */
     public function deleteByProductId($productId);
 }

--- a/Api/Data/CreditPriceDataInterface.php
+++ b/Api/Data/CreditPriceDataInterface.php
@@ -24,7 +24,7 @@ interface CreditPriceDataInterface
 
     /**
      * @param int $value
-     * @return CreditPriceDataInterface
+     * @return self
      */
     public function setId($value): CreditPriceDataInterface;
 
@@ -35,7 +35,7 @@ interface CreditPriceDataInterface
 
     /**
      * @param int $value
-     * @return CreditPriceDataInterface
+     * @return self
      */
     public function setProductId($value): CreditPriceDataInterface;
 
@@ -46,7 +46,7 @@ interface CreditPriceDataInterface
 
     /**
      * @param int $value
-     * @return CreditPriceDataInterface
+     * @return self
      */
     public function setTerm($value): CreditPriceDataInterface;
 
@@ -57,7 +57,7 @@ interface CreditPriceDataInterface
 
     /**
      * @param float $value
-     * @return CreditPriceDataInterface
+     * @return self
      */
     public function setMonthlyPayment($value): CreditPriceDataInterface;
 
@@ -68,7 +68,7 @@ interface CreditPriceDataInterface
 
     /**
      * @param float $value
-     * @return CreditPriceDataInterface
+     * @return self
      */
     public function setInstalmentRate($value): CreditPriceDataInterface;
 
@@ -79,7 +79,7 @@ interface CreditPriceDataInterface
 
     /**
      * @param float $value
-     * @return CreditPriceDataInterface
+     * @return self
      */
     public function setCostOfPurchase($value): CreditPriceDataInterface;
 
@@ -90,7 +90,7 @@ interface CreditPriceDataInterface
 
     /**
      * @param float $value
-     * @return CreditPriceDataInterface
+     * @return self
      */
     public function setTotalIncInterest($value): CreditPriceDataInterface;
 }

--- a/Api/Data/TransactionDetailDataInterface.php
+++ b/Api/Data/TransactionDetailDataInterface.php
@@ -30,19 +30,19 @@ interface TransactionDetailDataInterface
 
     /**
      * @param $id
-     * @return object
+     * @return self
      */
     public function setId($id);
 
     /**
      * @param int $orderId
-     * @return object
+     * @return self
      */
     public function setOrderId($orderId);
 
     /**
      * @param string $transactionSource
-     * @return object
+     * @return self
      */
     public function setTransactionSource($transactionSource);
 }

--- a/Model/ResourceModel/CreditPriceRepository.php
+++ b/Model/ResourceModel/CreditPriceRepository.php
@@ -68,6 +68,7 @@ class CreditPriceRepository implements CreditPriceRepositoryInterface
      */
     public function deleteByProductId($productId)
     {
+        /** @var CreditPrice\Collection $collection */
         $collection = $this->collectionFactory->create();
         $collection->addFieldToFilter('product_id', $productId);
         return $collection->walk('delete');


### PR DESCRIPTION
Fixes Magento 2 docblock coding standards as required from: https://devdocs.magento.com/guides/v2.3/coding-standards/docblock-standard-general.html

> It is encouraged to use the short form of the name to encourage readability and consistency with the type hint. **The only exception is in the Service/DTO classes due to tooling requirements**.