### PR TITLE
Null checking before returning in the Google Pay getClientToken method

### DIFF
--- a/Model/GooglePay/Ui/ConfigProvider.php
+++ b/Model/GooglePay/Ui/ConfigProvider.php
@@ -100,7 +100,7 @@ class ConfigProvider implements ConfigProviderInterface
             $this->clientToken = $this->adapter->generate($params);
         }
 
-        return $this->clientToken;
+        return $this->clientToken ?: '';
     }
 
     /**


### PR DESCRIPTION
This fixes an error on the cart and checkout when Braintree is not
configured yet.