### PR TITLE
This fixes some Loader-Icons running infinite on Magento 2.3.2

### DIFF
--- a/view/frontend/templates/paypal/button.phtml
+++ b/view/frontend/templates/paypal/button.phtml
@@ -8,14 +8,14 @@ use Magento\Braintree\Block\Paypal\Button;
 
 /** @var Button $block */
 try {
-    $paypalId = sprintf('paypal-%s-%d', $block->getContainerId(), random_int(PHP_INT_MIN, PHP_INT_MAX));
+    $paypalId = sprintf('%s-%d', $block->getContainerId(), random_int(PHP_INT_MIN, PHP_INT_MAX));
     $paypalCreditId = sprintf('paypalcredit-%s-%d', $block->getContainerId(), random_int(PHP_INT_MIN, PHP_INT_MAX));
 } catch (Exception $e) {
     /**
      * Exception only thrown if an appropriate source of randomness cannot be found.
      * https://www.php.net/manual/en/function.random-int.php
      */
-    $paypalId = sprintf('paypal-%s', $block->getContainerId());
+    $paypalId = sprintf('%s', $block->getContainerId());
     $paypalCreditId = sprintf('paypalcredit-%s', $block->getContainerId());
 }
 

--- a/view/frontend/web/js/view/payment/method-renderer/cc-form.js
+++ b/view/frontend/web/js/view/payment/method-renderer/cc-form.js
@@ -186,7 +186,7 @@ define(
                     // stop loader when frame will be loaded
                     if ($('#braintree-hosted-field-number').length) {
                         clearInterval(intervalId);
-                        fullScreenLoader.stopLoader();
+                        fullScreenLoader.stopLoader(true);
                     }
                 }, 500);
 

--- a/view/frontend/web/js/view/payment/method-renderer/paypal.js
+++ b/view/frontend/web/js/view/payment/method-renderer/paypal.js
@@ -237,6 +237,7 @@ define([
                 Braintree.setPayPalInstance(null);
             } else {
                 Braintree.setup();
+                this.enableButton();
             }
         },
 
@@ -392,7 +393,7 @@ define([
          */
         enableButton: function () {
             $('[data-button="place"]').removeAttr('disabled');
-            fullScreenLoader.stopLoader();
+            fullScreenLoader.stopLoader(true);
         },
 
         /**


### PR DESCRIPTION
Tested only for pay by PayPal(Braintree) and Credit Card (Braintree).
Not tested on PayPal-Credit oder Vault etc...