### PR TITLE
Fix for CVV validation bug when CVV not enabled in config

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/hosted-fields.js
+++ b/view/frontend/web/js/view/payment/method-renderer/hosted-fields.js
@@ -194,6 +194,12 @@ define([
          * @returns {boolean}
          */
         validateCvvNumber: function () {
+            var self = this;
+            
+            if (self.hasVerification() === false) {
+                return true;
+            }
+            
             return this.validateField(
                 'cc_cid',
                 (this.isValidCvvNumber === true)


### PR DESCRIPTION
Steps to replicate:

* Clean Magento 2 install
* Install Gene Braintree module v3.2.1
* Set 'CVV Verification' to 'No' in Checkout -> Advanced Braintree Settings
* Add product to basket
* Fill out all shipping fields and proceed to billing
* Select credit/debit card and 'place order'

Expected result:

Card information sent to Braintree and order placed.

Actual result:

Nothing happens due to CVV field validation failing