### PR TITLE
Test if 'billingAddress' has value before using

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/cc-form.js
+++ b/view/frontend/web/js/view/payment/method-renderer/cc-form.js
@@ -256,7 +256,9 @@ define(
                     billingAddress = this.lastBillingAddress;
                 }
 
-                billingCountryId = billingAddress.countryId;
+                if (billingAddress) {
+                    billingCountryId = billingAddress.countryId;
+                }
 
                 if (billingCountryId && validator.getCountrySpecificCardTypes(billingCountryId)) {
                     return validator.collectTypes(


### PR DESCRIPTION
When checking out with only virtual products in cart, this line of code is throwing an error because there are no address details already recorded.