### PR TITLE
M1 to M2 Migration Console Command

### DIFF
--- a/Console/VaultMigrate.php
+++ b/Console/VaultMigrate.php
@@ -1,0 +1,290 @@
+<?php
+declare(strict_types=1);
+
+namespace Magento\Braintree\Console;
+
+use Magento\Braintree\Model\Adapter\BraintreeAdapter;
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Framework\App\ResourceConnection\ConnectionFactory;
+use Magento\Framework\Encryption\EncryptorInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Vault\Api\PaymentTokenRepositoryInterface;
+use Magento\Vault\Model\PaymentTokenFactory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class VaultMigrate
+ */
+class VaultMigrate extends Command
+{
+    const HOST = 'host';
+    const DBNAME = 'dbname';
+    const USERNAME = 'username';
+    const PASSWORD = 'password';
+
+    const EAV_ATTRIBUTE_TABLE = 'eav_attribute';
+    const ATTRIBUTE_ID = 'attribute_id';
+    const ATTRIBUTE_CODE = 'attribute_code';
+
+    const CUSTOMER_ENTITY_TABLE = 'customer_entity_varchar';
+    const VALUE = 'value';
+
+    const CC_MAPPER = [
+        'american-express' => 'AE',
+        'discover' => 'DI',
+        'jcb' => 'JCB',
+        'mastercard' => 'MC',
+        'master-card' => 'MC',
+        'visa' => 'VI',
+        'maestro' => 'MI',
+        'diners-club' => 'DN',
+        'unionpay' => 'CUP'
+    ];
+
+    /**
+     * Array to store M1 customer details
+     *
+     * @var array $customers
+     */
+    private $customers = [];
+    /**
+     * @var ConnectionFactory
+     */
+    private $connectionFactory;
+    /**
+     * @var BraintreeAdapter
+     */
+    private $braintreeAdapter;
+    /**
+     * @var CustomerRepositoryInterface
+     */
+    private $customerRepository;
+    /**
+     * @var PaymentTokenFactory
+     */
+    private $paymentToken;
+    /**
+     * @var PaymentTokenRepositoryInterface
+     */
+    private $paymentTokenRepository;
+    /**
+     * @var Json
+     */
+    private $json;
+    /**
+     * @var EncryptorInterface
+     */
+    private $encryptor;
+
+    /**
+     * VaultMigrate constructor.
+     *
+     * @param ConnectionFactory $connectionFactory
+     * @param BraintreeAdapter $braintreeAdapter
+     * @param CustomerRepositoryInterface $customerRepository
+     * @param PaymentTokenFactory $paymentToken
+     * @param PaymentTokenRepositoryInterface $paymentTokenRepository
+     * @param EncryptorInterface $encryptor
+     * @param Json $json
+     * @param string|null $name
+     */
+    public function __construct(
+        ConnectionFactory $connectionFactory,
+        BraintreeAdapter $braintreeAdapter,
+        CustomerRepositoryInterface $customerRepository,
+        PaymentTokenFactory $paymentToken,
+        PaymentTokenRepositoryInterface $paymentTokenRepository,
+        EncryptorInterface $encryptor,
+        Json $json,
+        string $name = null
+    ) {
+        parent::__construct($name);
+        $this->connectionFactory = $connectionFactory;
+        $this->braintreeAdapter = $braintreeAdapter;
+        $this->customerRepository = $customerRepository;
+        $this->paymentToken = $paymentToken;
+        $this->paymentTokenRepository = $paymentTokenRepository;
+        $this->json = $json;
+        $this->encryptor = $encryptor;
+    }
+
+    protected function configure()
+    {
+        $options = [
+            new InputOption(self::HOST, null, InputOption::VALUE_REQUIRED, 'Hostname/IP. Port is optional'),
+            new InputOption(self::DBNAME, null, InputOption::VALUE_REQUIRED, 'Database name'),
+            new InputOption(
+                self::USERNAME,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Database username. Must have read access'
+            ),
+            new InputOption(self::PASSWORD, null, InputOption::VALUE_REQUIRED, 'Password')
+        ];
+
+        $this->setName('braintree:migrate');
+        $this->setDescription('Migrate stored cards from a Magento 1 database');
+        $this->setDefinition($options);
+
+        parent::configure();
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|void|null
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $host = $input->getOption(self::HOST);
+        $databaseName = $input->getOption(self::DBNAME);
+        $username = $input->getOption(self::USERNAME);
+        $password = $input->getOption(self::PASSWORD);
+
+        // Set DB connection details
+        $db = $this->createDbConnection($host, $databaseName, $username, $password);
+
+        // Get the `braintree_customer_id` attribute ID
+        $eavAttributeId = $this->getEavAttributeId($db);
+
+        // Find all instances of `braintree_customer_id` in the customer entity table
+        $results = $this->getBraintreeCustomers($db, $eavAttributeId);
+
+        $output->writeln('<info>'. count($results) .' stored cards found</info>');
+
+        // For each record, look up the Braintree ID
+        foreach ($results as $result) {
+
+            $this->
+
+            $output->write('<info>Search Braintree for Customer ID ' . $result['braintree_id'] . '...</info>');
+            $customer = $this->braintreeAdapter->getCustomerById($result['braintree_id']);
+
+            // If we find customer records, grab the important data
+            if ($customer) {
+                $output->writeln('<info>Customer found!</info>');
+
+                $customerData = [
+                    'braintree_id' => $result['braintree_id'],
+                    'email' => $customer->email
+                ];
+
+                if ($customer->creditCards) {
+                    // grab each stored credit card
+                    foreach ($customer->creditCards as $creditCard) {
+                        $customerData['storedCards'][] = [
+                            'token' => $creditCard->token,
+                            'expirationMonth' => $creditCard->expirationMonth,
+                            'expirationYear' => $creditCard->expirationYear,
+                            'last4' => $creditCard->last4,
+                            'cardType' => self::CC_MAPPER[str_replace(' ', '-', strtolower($creditCard->cardType))]
+                        ];
+                    }
+                }
+
+                // Add customer data to the main customer array
+                $this->customers[] = $customerData;
+            } else {
+                $output->writeln('<error>No records found</error>');
+            }
+        }
+
+        // For each customer, locate them in the M2 database
+        foreach ($this->customers as $customer) {
+            try {
+                // Customer entity can only have one unique email assigned, so this method is acceptable to use.
+                $m2Customer = $this->customerRepository->get($customer['email']);
+
+                $output->write('<info>Customer ' . $customer['braintree_id'] . ' found in Magento 2 store...</info>');
+
+                foreach ($customer['storedCards'] as $storedCard) {
+                    // Create new vault payment token.
+                    $vaultPaymentToken = $this->paymentToken->create(PaymentTokenFactory::TOKEN_TYPE_CREDIT_CARD);
+                    $vaultPaymentToken->setCustomerId($m2Customer->getId());
+                    $vaultPaymentToken->setPaymentMethodCode('braintree');
+                    $vaultPaymentToken->setExpiresAt(
+                        sprintf(
+                            '%s-%s-01 00:00:00',
+                            $storedCard['expirationYear'],
+                            $storedCard['expirationMonth']
+                        )
+                    );
+                    $vaultPaymentToken->setGatewayToken($storedCard['token']);
+                    $vaultPaymentToken->setTokenDetails($this->json->serialize([
+                        'type' => $storedCard['cardType'],
+                        'maskedCC' => $storedCard['last4'],
+                        'expirationDate' => $storedCard['expirationMonth'] .'/' . $storedCard['expirationYear']
+                    ]));
+                    $vaultPaymentToken->setPublicHash(
+                        $this->encryptor->getHash(
+                            $m2Customer->getId()
+                            . $vaultPaymentToken->getPaymentMethodCode()
+                            . $vaultPaymentToken->getType()
+                            . $vaultPaymentToken->getTokenDetails()
+                        )
+                    );
+
+                    if ($this->paymentTokenRepository->save($vaultPaymentToken)) {
+                        $output->writeln('<info>Card stored successfully!</info>');
+                    }
+                }
+            } catch (NoSuchEntityException $e) {
+                $output->writeln(
+                    '<error>Customer ' . $customer['braintree_id'] . ' not found in Magento 2 store</error>'
+                );
+            } catch (LocalizedException $e) {
+                $output->writeln('<error>Failed to store card details.</error>');
+            }
+        }
+
+        $output->writeln('<info>Migration complete</info>');
+    }
+
+    /**
+     * @param $host
+     * @param $databaseName
+     * @param $username
+     * @param null $password
+     * @return \Magento\Framework\DB\Adapter\AdapterInterface
+     */
+    protected function createDbConnection($host, $databaseName, $username, $password = null)
+    {
+        return $this->connectionFactory->create([
+            'host' => $host,
+            'dbname' => $databaseName,
+            'username' => $username,
+            'password' => $password ?? null
+        ]);
+    }
+
+    /**
+     * @param \Magento\Framework\DB\Adapter\AdapterInterface $db
+     * @return string
+     */
+    private function getEavAttributeId(\Magento\Framework\DB\Adapter\AdapterInterface $db)
+    {
+        $select = $db->select()
+            ->where('attribute_code = ?', 'braintree_customer_id')
+            ->from(self::EAV_ATTRIBUTE_TABLE, self::ATTRIBUTE_ID);
+        return $db->fetchOne($select);
+    }
+
+    /**
+     * @param \Magento\Framework\DB\Adapter\AdapterInterface $db
+     * @param string $eavAttributeId
+     * @return array
+     */
+    private function getBraintreeCustomers(\Magento\Framework\DB\Adapter\AdapterInterface $db, string $eavAttributeId)
+    {
+        $select = $db->select()
+            ->join('customer_entity', 'customer_entity.entity_id = customer_entity_varchar.entity_id')
+            ->where(self::ATTRIBUTE_ID . ' = ?', $eavAttributeId)
+            ->from(self::CUSTOMER_ENTITY_TABLE, self::VALUE . ' as braintree_id');
+        return $db->fetchAll($select);
+    }
+}

--- a/Console/VaultMigrate.php
+++ b/Console/VaultMigrate.php
@@ -97,6 +97,7 @@ class VaultMigrate extends Command
      * @param PaymentTokenRepositoryInterface $paymentTokenRepository
      * @param EncryptorInterface $encryptor
      * @param SerializerInterface $json
+     * @param StoreManagerInterface $storeManager
      * @param string|null $name
      */
     public function __construct(
@@ -275,6 +276,8 @@ class VaultMigrate extends Command
             $output->writeln('<info>'. count($result) .' stored cards found</info>');
             return $result;
         }
+
+        return false;
     }
 
     /**

--- a/Console/VaultMigrate.php
+++ b/Console/VaultMigrate.php
@@ -159,6 +159,7 @@ class VaultMigrate extends Command
      * @param InputInterface $input
      * @param OutputInterface $output
      * @return int|void|null
+     * @throws NotFound
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/Model/Adapter/BraintreeAdapter.php
+++ b/Model/Adapter/BraintreeAdapter.php
@@ -8,6 +8,8 @@ namespace Magento\Braintree\Model\Adapter;
 use Braintree\ClientToken;
 use Braintree\Configuration;
 use Braintree\CreditCard;
+use Braintree\Customer;
+use Braintree\CustomerSearch;
 use Braintree\PaymentMethod;
 use Braintree\PaymentMethodNonce;
 use Braintree\ResourceCollection;
@@ -242,5 +244,10 @@ class BraintreeAdapter
     public function updatePaymentMethod($token, $attribs)
     {
         return PaymentMethod::update($token, $attribs);
+    }
+
+    public function getCustomerById($id)
+    {
+        return Customer::find($id);
     }
 }

--- a/Model/Adapter/BraintreeAdapter.php
+++ b/Model/Adapter/BraintreeAdapter.php
@@ -10,6 +10,7 @@ use Braintree\Configuration;
 use Braintree\CreditCard;
 use Braintree\Customer;
 use Braintree\CustomerSearch;
+use Braintree\Exception\NotFound;
 use Braintree\PaymentMethod;
 use Braintree\PaymentMethodNonce;
 use Braintree\ResourceCollection;
@@ -246,6 +247,11 @@ class BraintreeAdapter
         return PaymentMethod::update($token, $attribs);
     }
 
+    /**
+     * @param $id
+     * @return Customer
+     * @throws NotFound
+     */
     public function getCustomerById($id)
     {
         return Customer::find($id);

--- a/Test/Unit/Console/VaultMigrateTest.php
+++ b/Test/Unit/Console/VaultMigrateTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Magento\Braintree\Test\Console;
+
+use Magento\Braintree\Console\VaultMigrate;
+use Magento\Braintree\Model\Adapter\BraintreeAdapter;
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Framework\App\ResourceConnection\ConnectionFactory;
+use Magento\Framework\Encryption\EncryptorInterface;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Vault\Api\PaymentTokenRepositoryInterface;
+use Magento\Vault\Model\PaymentTokenFactory;
+use Magento\Vault\Test\Block\Onepage\Payment\Method\Vault;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Class VaultMigrateTest
+ */
+class VaultMigrateTest extends TestCase
+{
+    /**
+     * @var MockObject|ConnectionFactory
+     */
+    private $connectionFactoryMock;
+    /**
+     * @var MockObject|BraintreeAdapter
+     */
+    private $braintreeAdapterMock;
+    /**
+     * @var MockObject|CustomerRepositoryInterface
+     */
+    private $customerRepositoryMock;
+    /**
+     * @var MockObject|PaymentTokenFactory
+     */
+    private $paymentTokenFactoryMock;
+    /**
+     * @var MockObject|PaymentTokenRepositoryInterface
+     */
+    private $paymentTokenRepositoryMock;
+    /**
+     * @var MockObject|EncryptorInterface
+     */
+    private $encryptorMock;
+    /**
+     * @var MockObject|SerializerInterface
+     */
+    private $jsonMock;
+    /**
+     * @var MockObject|VaultMigrate
+     */
+    private $command;
+
+    public function setUp()
+    {
+        $this->connectionFactoryMock = $this->createMock(ConnectionFactory::class);
+        $this->braintreeAdapterMock = $this->createMock(BraintreeAdapter::class);
+        $this->customerRepositoryMock = $this->createMock(CustomerRepositoryInterface::class);
+        $this->paymentTokenFactoryMock = $this->createMock(PaymentTokenFactory::class);
+        $this->paymentTokenRepositoryMock = $this->createMock(PaymentTokenRepositoryInterface::class);
+        $this->encryptorMock = $this->createMock(EncryptorInterface::class);
+        $this->jsonMock = $this->createMock(SerializerInterface::class);
+
+        $this->command = new VaultMigrate(
+            $this->connectionFactoryMock,
+            $this->braintreeAdapterMock,
+            $this->customerRepositoryMock,
+            $this->paymentTokenFactoryMock,
+            $this->paymentTokenRepositoryMock,
+            $this->encryptorMock,
+            $this->jsonMock
+        );
+    }
+
+    /**
+     * @param $customers
+     * @dataProvider remapCustomerDataDataProvider
+     */
+    public function testRemapCustomerData($customers)
+    {
+        $foo = $this->command->remapCustomerData($customers);
+        $this->assertArrayHasKey('braintree_id', $foo[0]);
+        $this->assertArrayHasKey('email', $foo[0]);
+        $this->assertArrayHasKey('storedCards', $foo[0]);
+        $this->assertGreaterThanOrEqual(1, $foo[0]['storedCards']);
+    }
+
+    /**
+     * @return array
+     */
+    public function remapCustomerDataDataProvider(): array
+    {
+        return [
+            [
+                [
+                    (object) [
+                        'id' => '886658184',
+                        'email' => 'roni_cost@example.com',
+                        'creditCards' => [
+                            (object) [
+                                'token' => '5p7529',
+                                'expirationMonth' => '01',
+                                'expirationYear' => '2021',
+                                'last4' => '1000',
+                                'cardType' => 'Visa'
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @param $description
+     * @dataProvider getOptionListDataProvider
+     */
+    public function testGetOptionsList($description)
+    {
+        /* @var \Symfony\Component\Console\Input\InputArgument[] $argsList */
+        $argsList = $this->command->getOptionsList();
+
+        $this->assertEquals(VaultMigrate::HOST, $argsList[0]->getName());
+        $this->assertEquals($description, $argsList[0]->getDescription());
+    }
+
+    /**
+     * @return array
+     */
+    public function getOptionListDataProvider()
+    {
+        return [
+            [
+                'description' => 'Hostname/IP. Port is optional'
+            ]
+        ];
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1033,4 +1033,12 @@
     <type name="Magento\Framework\View\Asset\Minification">
         <plugin name="braintreeExcludeFromMinification" type="Magento\Braintree\Plugin\ExcludeFromMinification"/>
     </type>
+
+    <type name="Magento\Framework\Console\CommandList">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="braintreeMigrate" xsi:type="object">Magento\Braintree\Console\VaultMigrate</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
This PR introduces the new M1 to M2 Migration console command that allows for the migration of stored cards from a Magento 1 database, into the Magento 2 store.

The console command will connect to the remote M1 database, locate customers that have an assigned Braintree Id and look them up in the Braintree account.

For this reason, the command should be ran with Braintree set to Production mode.

Currently, only basic unit testing is implemented, with the understanding that Integration Tests need to be added.

**Usage**

Run `bin/magento braintree:migrate --host=<host/ip> --dbname=<db name> --username=<db username> --password=<db password>`

NB - `--username` and `--password` can be supplied either as an argument or if not, they will be asked as interactive questions.