### PR TITLE
Replace let with var for backwards compatibility with older browsers

### DIFF
--- a/view/adminhtml/templates/payment/script.phtml
+++ b/view/adminhtml/templates/payment/script.phtml
@@ -18,7 +18,7 @@ $code = $block->escapeHtml($block->getCode());
             'jquery',
             'domReady!'
         ], function(Braintree, $) {
-            let config = <?= /* @noEscape */ $block->getPaymentConfig() ?>,
+            var config = <?= /* @noEscape */ $block->getPaymentConfig() ?>,
                 payment,
                 form = $('#payment_form_<?= /* @noEscape */ $code ?>');
 

--- a/view/adminhtml/templates/virtual/script.phtml
+++ b/view/adminhtml/templates/virtual/script.phtml
@@ -18,7 +18,7 @@ $code = $block->escapeHtml($block->getCode());
             'jquery',
             'domReady!'
         ], function(Braintree, $) {
-            let config = <?= /* @noEscape */ $block->getPaymentConfig() ?>,
+            var config = <?= /* @noEscape */ $block->getPaymentConfig() ?>,
                 payment;
             payment = new Braintree(config);
         });

--- a/view/frontend/web/js/applepay/api.js
+++ b/view/frontend/web/js/applepay/api.js
@@ -35,7 +35,7 @@ define(
                 if (!this.countryDirectory) {
                     storage.get("rest/V1/directory/countries").done(function (result) {
                         this.countryDirectory = {};
-                        let i, data, x, region;
+                        var i, data, x, region;
                         for (i = 0; i < result.length; ++i) {
                             data = result[i];
                             this.countryDirectory[data.two_letter_abbreviation] = {};
@@ -167,10 +167,10 @@ define(
              */
             onShippingContactSelect: function (event, session) {
                 // Get the address.
-                let address = event.shippingContact;
+                var address = event.shippingContact;
 
                 // Create a payload.
-                let payload = {
+                var payload = {
                     address: {
                         city: address.locality,
                         region: address.administrativeArea,
@@ -194,16 +194,16 @@ define(
                         return false;
                     }
 
-                    let shippingMethods = [];
+                    var shippingMethods = [];
                     this.shippingMethods = {};
 
                     // Format shipping methods array.
-                    for (let i = 0; i < result.length; i++) {
+                    for (var i = 0; i < result.length; i++) {
                         if (typeof result[i].method_code !== 'string') {
                             continue;
                         }
 
-                        let method = {
+                        var method = {
                             identifier: result[i].method_code,
                             label: result[i].method_title,
                             detail: result[i].carrier_title ? result[i].carrier_title : "",
@@ -221,7 +221,7 @@ define(
                     }
 
                     // Create payload to get totals
-                    let totalsPayload = {
+                    var totalsPayload = {
                         "addressInformation": {
                             "address": {
                                 "countryId": this.shippingAddress.country_id,
@@ -275,10 +275,10 @@ define(
              * Record which shipping method has been selected & Updated totals
              */
             onShippingMethodSelect: function (event, session) {
-                let shippingMethod = event.shippingMethod;
+                var shippingMethod = event.shippingMethod;
                 this.shippingMethod = shippingMethod.identifier;
 
-                let payload = {
+                var payload = {
                     "addressInformation": {
                         "address": {
                             "countryId": this.shippingAddress.country_id,
@@ -316,7 +316,7 @@ define(
              * Place the order
              */
             startPlaceOrder: function (nonce, event, session) {
-                let shippingContact = event.payment.shippingContact,
+                var shippingContact = event.payment.shippingContact,
                     billingContact = event.payment.billingContact,
                     payload = {
                         "addressInformation": {

--- a/view/frontend/web/js/model/step-navigator-mixin.js
+++ b/view/frontend/web/js/model/step-navigator-mixin.js
@@ -4,7 +4,7 @@ define([
 ], function (wrapper, $) {
     'use strict';
 
-    let mixin = {
+    var mixin = {
         handleHash: function (originalFn) {
             var hashString = window.location.hash.replace('#', '');
             return (hashString.includes('venmo')) ? false : originalFn();

--- a/view/frontend/web/js/view/payment/braintree.js
+++ b/view/frontend/web/js/view/payment/braintree.js
@@ -15,7 +15,7 @@ define(
     ) {
         'use strict';
 
-        let config = window.checkoutConfig.payment,
+        var config = window.checkoutConfig.payment,
             braintreeType = 'braintree',
             payPalType = 'braintree_paypal',
             payPalCreditType = 'braintree_paypal_credit',

--- a/view/frontend/web/js/view/payment/method-renderer/ach.js
+++ b/view/frontend/web/js/view/payment/method-renderer/ach.js
@@ -58,9 +58,9 @@ define(
 
                 var billingAddress = quote.billingAddress();
 
-                let regionCode;
+                var regionCode;
 
-                let bankDetails = {
+                var bankDetails = {
                     routingNumber: self.routingNumber(),
                     accountNumber: self.accountNumber(),
                     accountType: self.accountType(),
@@ -132,7 +132,7 @@ define(
             },
 
             getData: function () {
-                let data = {
+                var data = {
                     'method': this.getCode(),
                     'additional_data': {
                         'payment_method_nonce': this.paymentMethodNonce,

--- a/view/frontend/web/js/view/payment/method-renderer/lpm.js
+++ b/view/frontend/web/js/view/payment/method-renderer/lpm.js
@@ -160,7 +160,7 @@ define(
             },
 
             getData: function () {
-                let data = {
+                var data = {
                     'method': this.getCode(),
                     'additional_data': {
                         'payment_method_nonce': this.paymentMethodNonce,

--- a/view/frontend/web/js/view/payment/method-renderer/venmo.js
+++ b/view/frontend/web/js/view/payment/method-renderer/venmo.js
@@ -75,7 +75,7 @@ define(
             },
 
             getData: function () {
-                let data = {
+                var data = {
                     'method': this.getCode(),
                     'additional_data': {
                         'payment_method_nonce': this.paymentMethodNonce,


### PR DESCRIPTION
Resolves an error with older browsers not supporting the `let` keyword whilst in strict mode.

```
SyntaxError: Unexpected use of reserved word 'let' in strict mode
```

Found this issue on Safari v9.1.3 which caused the Paypal button and payment methods not to load for customers using old browser versions.

Browser support for `let` keyword here: https://caniuse.com/#feat=let

Appreciate these are very outdated but it's a relatively low risk change to resolve an error with a piece of critical functionality.