### PR TITLE
Add `uk-maestro` to CC Types to fully support Maestro cards.

### DIFF
--- a/Gateway/Response/CardDetailsHandler.php
+++ b/Gateway/Response/CardDetailsHandler.php
@@ -53,7 +53,10 @@ class CardDetailsHandler implements HandlerInterface
     }
 
     /**
-     * @inheritdoc
+     * @param array $handlingSubject
+     * @param array $response
+     * @throws InputException
+     * @throws NoSuchEntityException
      */
     public function handle(array $handlingSubject, array $response)
     {
@@ -67,7 +70,6 @@ class CardDetailsHandler implements HandlerInterface
         $payment->setCcLast4($creditCard[self::CARD_LAST4]);
         $payment->setCcExpMonth($creditCard[self::CARD_EXP_MONTH]);
         $payment->setCcExpYear($creditCard[self::CARD_EXP_YEAR]);
-
         $payment->setCcType($this->getCreditCardType($creditCard[self::CARD_TYPE]));
 
         // set card details to additional info
@@ -83,7 +85,7 @@ class CardDetailsHandler implements HandlerInterface
      * @throws InputException
      * @throws NoSuchEntityException
      */
-    private function getCreditCardType($type): string
+    private function getCreditCardType(string $type): string
     {
         $replaced = str_replace(' ', '-', strtolower($type));
         $mapper = $this->config->getCcTypesMapper();

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -30,7 +30,7 @@
                 <can_deny_payment>1</can_deny_payment>
                 <cctypes>AE,VI,MC,DI,JCB,CUP,DN,MI</cctypes>
                 <useccv>1</useccv>
-                <cctypes_braintree_mapper><![CDATA[{"american-express":"AE","discover":"DI","jcb":"JCB","mastercard":"MC","master-card":"MC","visa":"VI","maestro":"MI","diners-club":"DN","unionpay":"CUP"}]]></cctypes_braintree_mapper>
+                <cctypes_braintree_mapper><![CDATA[{"american-express":"AE","discover":"DI","jcb":"JCB","mastercard":"MC","master-card":"MC","visa":"VI","maestro":"MI","uk-maestro":"MI","diners-club":"DN","unionpay":"CUP"}]]></cctypes_braintree_mapper>
                 <order_status>processing</order_status>
                 <environment>sandbox</environment>
                 <allowspecific>0</allowspecific>


### PR DESCRIPTION
Whilst `maestro` was in the config.xml, some cards return the string `UK Maestro` which gets translated to `uk-maestro` in the `CardDetailsHandler` class.

The result of the missing card type was an undefined index error when `getCreditCardType()` was called.