### PR TITLE
Adding proxy to customer repository to fix install error

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1152,6 +1152,7 @@
     <type name="Magento\Braintree\Console\VaultMigrate">
         <arguments>
             <argument name="braintreeAdapter" xsi:type="object">Magento\Braintree\Model\Adapter\BraintreeAdapter\Proxy</argument>
+            <argument name="customerRepository" xsi:type="object">Magento\Customer\Model\ResourceModel\CustomerRepository\Proxy</argument>
         </arguments>
     </type>
 </config>


### PR DESCRIPTION
When this module is present during an initial Magento install, the following error occurs:
```
484 Installing database schema:
485 In Mysql.php line 110:
486                                                                                
487   SQLSTATE[42S02]: Base table or view not found: 1146 Table 'build_db.eav_ent  
488   ity_type' doesn't exist, query was: SELECT `main_table`.* FROM `eav_entity_  
489   type` AS `main_table`                                                        
490                                                                                
491 In Mysql.php line 91:
492                                                                                
493   SQLSTATE[42S02]: Base table or view not found: 1146 Table 'build_db.eav_ent  
494   ity_type' doesn't exist      
```

The reason for this is the `VaultMigrate` CLI command is loaded, which calls `CustomerRepository`. In this chain, a call to the database is made from a class' constructor (a bad idea for this very reason), and that causes this error.

Adding the proxy resolves the problem efficiently with minimal changes to the code.