### PR TITLE
return type CreditPriceDataInterface

### DIFF
--- a/Model/ResourceModel/CreditPriceRepository.php
+++ b/Model/ResourceModel/CreditPriceRepository.php
@@ -34,7 +34,8 @@ class CreditPriceRepository implements CreditPriceRepositoryInterface
      */
     public function save(CreditPriceDataInterface $entity): CreditPriceDataInterface
     {
-        return $entity->getResource()->save($entity);
+        $entity->getResource()->save($entity);
+        return $entity;
     }
 
     /**


### PR DESCRIPTION
Resolves

```
PHP Fatal error:  Uncaught TypeError: Return value of Magento\Braintree\Model\ResourceModel\CreditPriceRepository::save() must implement interface Magento\Braintree\Api\Data\CreditPriceDataInterface, instance of Magento\Braintree\Model\ResourceModel\CreditPrice returned
```