### PR TITLE
Add subscribe method and additional checks to hash change event

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/paypal.js
+++ b/view/frontend/web/js/view/payment/method-renderer/paypal.js
@@ -98,7 +98,19 @@ define([
                 .observe(['active', 'isReviewRequired', 'customerEmail']);
 
             window.addEventListener('hashchange', function (e) {
-                if (e.newURL.indexOf('payment') > 0 && self.grandTotalAmount !== null) {
+                var methodCode = quote.paymentMethod();
+
+                if (methodCode === 'braintree_paypal' || methodCode === 'braintree_paypal_vault') {
+                    if (e.newURL.indexOf('payment') > 0 && self.grandTotalAmount !== null) {
+                        self.reInitPayPal();
+                    }
+                }
+            });
+
+            quote.paymentMethod.subscribe(function (value) {
+                var methodCode = value;
+
+                if (methodCode === 'braintree_paypal' || methodCode === 'braintree_paypal_vault') {
                     self.reInitPayPal();
                 }
             });


### PR DESCRIPTION
- Only re-init PayPal on hash change if existing method was PayPal
- Locally, this stops PayPal component hijacking card payments
- Tested, correct method code is sent
- Also added subscribe in case user switched from card to PayPal