### PR TITLE
'three_d_secure' was removed in version 4.x.x

### DIFF
--- a/Test/Unit/Gateway/Request/ThreeDSecureDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/ThreeDSecureDataBuilderTest.php
@@ -124,14 +124,14 @@ class ThreeDSecureDataBuilderTest extends \PHPUnit\Framework\TestCase
         return [
             ['verify' => true, 'amount' => 20, 'countryId' => 'US', 'countries' => [], 'result' => [
                 'options' => [
-                    'three_d_secure' => [
+                    'threeDSecure' => [
                         'required' => true
                     ]
                 ]
             ]],
             ['verify' => true, 'amount' => 0, 'countryId' => 'US', 'countries' => ['US', 'GB'], 'result' => [
                 'options' => [
-                    'three_d_secure' => [
+                    'threeDSecure' => [
                         'required' => true
                     ]
                 ]


### PR DESCRIPTION
As stated in ThreeDSecureDataBuilder.php "// 'three_d_secure' was removed in version 4.x.x" the array key is now named "threeDSecure" instead of "three_d_secure". Tests did not pass because of this issue.