### PR TITLE
Unit Test failed - wrong constructor invocation

### DIFF
--- a/Test/Unit/Model/Paypal/Helper/QuoteUpdaterTest.php
+++ b/Test/Unit/Model/Paypal/Helper/QuoteUpdaterTest.php
@@ -5,6 +5,8 @@ namespace Magento\Braintree\Test\Unit\Model\Paypal\Helper;
 use InvalidArgumentException;
 use Magento\Braintree\Gateway\Config\PayPal\Config;
 use Magento\Braintree\Model\Paypal\Helper\QuoteUpdater;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Directory\Model\Region;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Model\Quote;
@@ -39,22 +41,29 @@ class QuoteUpdaterTest extends TestCase
     private $messageManagerMock;
 
     /**
-     * @var Address|MockObject
+     * @var ResourceConnection|MockObject
      */
-    private $addressMock;
+    private $resourceConnectionMock;
+
+    /**
+     * @var Region|MockObject
+     */
+    private $regionMock;
 
     protected function setUp()
     {
         $this->configMock = $this->getMockBuilder(Config::class)->disableOriginalConstructor()->getMock();
         $this->quoteRepositoryMock = $this->getMockBuilder(CartRepositoryInterface::class)->getMockForAbstractClass();
         $this->messageManagerMock = $this->getMockBuilder(ManagerInterface::class)->getMockForAbstractClass();
-        $this->addressMock = $this->getMockBuilder(Address::class)->disableOriginalConstructor()->getMock();
+        $this->resourceConnectionMock = $this->getMockBuilder(ResourceConnection::class)->disableOriginalConstructor()->getMock();
+        $this->regionMock = $this->getMockBuilder(Region::class)->disableOriginalConstructor()->getMock();
 
         $this->quoteUpdater = new QuoteUpdater(
             $this->configMock,
             $this->quoteRepositoryMock,
             $this->messageManagerMock,
-            $this->addressMock
+            $this->resourceConnectionMock,
+            $this->regionMock
         );
     }
 


### PR DESCRIPTION
The unit test resulted in error because QuoteUpdater does not accept an Address as 4th parameter anymore, but needs a different 4th and additional 5th parameter.