### PR TITLE
float getPrice due to inconsistent return

### DIFF
--- a/Gateway/Request/Level23ProcessingDataBuilder.php
+++ b/Gateway/Request/Level23ProcessingDataBuilder.php
@@ -109,15 +109,17 @@ class Level23ProcessingDataBuilder implements BuilderInterface
                 ]
             );
 
+            $itemPrice = (float) $item->getPrice();
+
             $lineItems[] = array_combine(
                 self::LINE_ITEMS_ARRAY,
                 [
                     $filteredFields['name'],
                     TransactionLineItem::DEBIT,
                     $this->numberToString($item->getQtyOrdered(), 2),
-                    $this->numberToString($item->getBasePrice(), 2),
+                    $this->numberToString($itemPrice, 2),
                     $filteredFields['unit_of_measure'],
-                    $this->numberToString($item->getQtyOrdered() * $item->getBasePrice(), 2),
+                    $this->numberToString($item->getQtyOrdered() * $itemPrice, 2),
                     $item->getTaxAmount() === null ? '0.00' : $this->numberToString($item->getTaxAmount(), 2),
                     $item->getDiscountAmount() === null ? '0.00' : $this->numberToString($item->getDiscountAmount(), 2),
                     $filteredFields['sku'],


### PR DESCRIPTION
getPrice() should return a float, or null, according to /vendor/magento/module-sales/Api/Data/OrderItemInterface.php but when setting a custom price from the admin, it is returned as a string, breaking the Level 2/3 Processing data builder class.

getBasePrice() has a similar issue if fixed price levels are set at the product level.

Both these issues should be fixed in Magento 2.3.5 but for now we should just use getPrice() and force the float.