### PR TITLE
Fix integration test setup crash

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1152,6 +1152,7 @@
     <type name="Magento\Braintree\Console\VaultMigrate">
         <arguments>
             <argument name="braintreeAdapter" xsi:type="object">Magento\Braintree\Model\Adapter\BraintreeAdapter\Proxy</argument>
+            <argument name="customerRepository" xsi:type="object">Magento\Customer\Api\CustomerRepositoryInterface\Proxy</argument>
         </arguments>
     </type>
 </config>


### PR DESCRIPTION
Currently integration test setup:install will fail with a MySQL error:
SQLSTATE[42S02]: Base table or view not found: 1146 Table 'magento_integration_tests.eav_entity_type' doesn't exist, query was: SELECT .* FROM  AS

Fix by replacing the Magento\Braintree\Console\VaultMigrate customerRepository argument with a proxy.