### PR TITLE
Bugfix/missing braintree adapter factory

### DIFF
--- a/Model/Adapter/BraintreeAdapterFactory.php
+++ b/Model/Adapter/BraintreeAdapterFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Magento\Braintree\Model\Adapter;
+
+use Magento\Braintree\Gateway\Config\Config;
+use Magento\Framework\ObjectManagerInterface;
+
+/**
+ * This factory is preferable to use for Braintree adapter instance creation.
+ */
+class BraintreeAdapterFactory
+{
+    /** @var ObjectManagerInterface */
+    private $objectManager;
+
+    /** @var Config */
+    private $config;
+
+    public function __construct(ObjectManagerInterface $objectManager, Config $config)
+    {
+        $this->config = $config;
+        $this->objectManager = $objectManager;
+    }
+
+    /**
+     * Creates instance of Braintree Adapter.
+     *
+     * @param int|null $storeId if null is provided as an argument, then current scope will be resolved
+     * by \Magento\Framework\App\Config\ScopeCodeResolver (useful for most cases) but for adminhtml area the store
+     * should be provided as the argument for correct config settings loading.
+     * @return BraintreeAdapter
+     */
+    public function create($storeId = null)
+    {
+        return $this->objectManager->create(
+            BraintreeAdapter::class, [
+                'merchantId' => $this->config->getMerchantId($storeId),
+                'publicKey' => $this->config->getValue(Config::KEY_PUBLIC_KEY, $storeId),
+                'privateKey' => $this->config->getValue(Config::KEY_PRIVATE_KEY, $storeId),
+                'environment' => $this->config->getEnvironment($storeId),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Original module magento/module-braintree has class BraintreeAdapterFactory - this class is missing in your package and causing issues in graphql endpoints:

`Argument 1 passed to Magento\Braintree\Model\Adapter\BraintreeAdapterFactory::create() must be of the type array, integer given, called in /var/www/public/vendor/magento/module-braintree-graph-ql/Model/Resolver/CreateBraintreeClientToken.php on line 68`

That's because magento2 creates default factory class, where an argument has type hint array (not int), which causes type error.

In this pull request, I've just added this missing factory class.