### PR TITLE
resolve descriptors from current store

### DIFF
--- a/Gateway/Config/Config.php
+++ b/Gateway/Config/Config.php
@@ -340,7 +340,10 @@ class Config extends \Magento\Payment\Gateway\Config\Config
     {
         $values = [];
         foreach (self::$dynamicDescriptorKeys as $key) {
-            $value = $this->getValue('descriptor_' . $key);
+            $value = $this->getValue(
+                'descriptor_' . $key,
+                $this->storeConfigResolver->getStoreId()
+            );
             if (!empty($value)) {
                 $values[$key] = $value;
             }


### PR DESCRIPTION
If you've got multiple stores set up, with different descriptors configured, the call to `getValue` wasn't scoped to the current store when entering an order via the admin control panel.

This fix will scope the descriptor_ values to the current store, like the rest of the configurations in this file.