### PR TITLE
[PBSD-41] PayPal Credit field will only be available if Merchant Country is either US or UK.

### DIFF
--- a/Block/System/Config/Form/Fieldset.php
+++ b/Block/System/Config/Form/Fieldset.php
@@ -45,7 +45,7 @@ class Fieldset extends Payment
     }
 
     /**
-     * Remove UK specific fields from the form when on a non-UK merchant country
+     * Remove US & UK specific fields from the form if merchant country is not UK or US.
      *
      * @inheritDoc
      */
@@ -68,7 +68,11 @@ class Fieldset extends Payment
             );
         }
 
+        // Only available to GB and US
         if ($locale !== 'gb' && $locale !== 'us') {
+            $element->removeField(
+                'payment_' . $locale . '_braintree_section_braintree_braintree_paypal_credit_active'
+            );
             $element->removeField(
                 'payment_other_braintree_section_braintree_braintree_paypal_credit_active'
             );

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -36,7 +36,7 @@
                         <label>Enable PayPal Credit through Braintree</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/braintree_paypal_credit/active</config_path>
-                        <comment>PayPal Credit is currently only available in the United States and United Kingdom. PayPal Credit will be disabled if the selected value for the Merchant Country field is not US or UK.</comment>
+                        <comment>PayPal Credit is currently only available in the United States and United Kingdom. PayPal Credit will be disabled if the selected value for the Merchant Country field is not US or UK. This field is only available if Merchant Country is US or UK.</comment>
                         <requires>
                             <group id="braintree_required"/>
                         </requires>


### PR DESCRIPTION
**Enable PayPal Credit through Braintree** field will only be available if Merchant Country is either the **US** or **UK** as it does not support other countries.