### PR TITLE
save paypal phone on shipping address (3.4)

### DIFF
--- a/Model/Paypal/Helper/QuoteUpdater.php
+++ b/Model/Paypal/Helper/QuoteUpdater.php
@@ -242,6 +242,10 @@ class QuoteUpdater extends AbstractHelper
 
         $address->setCountryId($addressData['countryCodeAlpha2']);
         $address->setPostcode($addressData['postalCode']);
+        
+        if (isset($addressData['telephone'])) {
+            $address->setTelephone($addressData['telephone']);
+        }
 
         // PayPal's address supposes not saving against customer account
         $address->setSaveInAddressBook(false);


### PR DESCRIPTION
PayPal could optionally be set to require phone number.    

This saves it in Magento on the shipping address, if it's present.