### PR TITLE
[PBSD-50] Fixed Braintree Credit Card and Default PayPal Express Checkout conflicts issue.

### DIFF
--- a/view/base/requirejs-config.js
+++ b/view/base/requirejs-config.js
@@ -1,6 +1,6 @@
 /**
  * Config to pull in all the relevant Braintree JS SDKs
- * @type {{paths: {braintreePayPalCheckout: string, braintreeHostedFields: string, braintreeDataCollector: string, braintreeThreeDSecure: string, braintreeGooglePay: string, braintreeApplePay: string, googlePayLibrary: string}, map: {"*": {braintree: string}}}}
+ * @type {{paths: {braintreePayPalInContextCheckout: string, braintreePayPalCheckout: string, braintreeVenmo: string, braintreeHostedFields: string, braintreeDataCollector: string, braintreeThreeDSecure: string, braintreeGooglePay: string, braintreeApplePay: string, braintreeAch: string, braintreeLpm: string, googlePayLibrary: string}, map: {"*": {braintree: string}}}}
  */
 var config = {
     map: {
@@ -19,6 +19,7 @@ var config = {
         "braintreeVenmo": 'https://js.braintreegateway.com/web/3.51.0/js/venmo.min',
         "braintreeAch": "https://js.braintreegateway.com/web/3.51.0/js/us-bank-account.min",
         "braintreeLpm": "https://js.braintreegateway.com/web/3.51.0/js/local-payment.min",
-        "googlePayLibrary": "https://pay.google.com/gp/p/js/pay"
+        "googlePayLibrary": "https://pay.google.com/gp/p/js/pay",
+        "braintreePayPalInContextCheckout": "https://www.paypalobjects.com/api/checkout"
     }
 };

--- a/view/frontend/web/js/paypal/button.js
+++ b/view/frontend/web/js/paypal/button.js
@@ -15,7 +15,7 @@ define(
         'braintreeCheckoutPayPalAdapter',
         'Magento_Braintree/js/form-builder',
         'domReady!',
-        'https://www.paypalobjects.com/api/checkout.js'
+        'braintreePayPalInContextCheckout'
     ],
     function (
         resolver,

--- a/view/frontend/web/js/view/payment/adapter.js
+++ b/view/frontend/web/js/view/payment/adapter.js
@@ -9,12 +9,10 @@ define([
     'braintree',
     'braintreeDataCollector',
     'braintreeHostedFields',
-    'braintreePayPalCheckout',
     'Magento_Checkout/js/model/full-screen-loader',
     'Magento_Ui/js/model/messageList',
-    'mage/translate',
-    'https://www.paypalobjects.com/api/checkout.js'
-], function ($, client, dataCollector, hostedFields, paypalCheckout, fullScreenLoader, globalMessageList, $t) {
+    'mage/translate'
+], function ($, client, dataCollector, hostedFields, fullScreenLoader, globalMessageList, $t) {
     'use strict';
 
     return {
@@ -276,133 +274,6 @@ define([
 
                 this.config.onInstanceReady(hostedFieldsInstance);
                 this.hostedFieldsInstance = hostedFieldsInstance;
-            }.bind(this));
-        },
-
-        /**
-         * Setup pyapal instance
-         */
-        setupPaypal: function () {
-            var self = this;
-
-            if (this.config.paypalInstance) {
-                fullScreenLoader.stopLoader(true);
-                return;
-            }
-
-            paypalCheckout.create({
-                client: this.clientInstance
-            }, function (createErr, paypalCheckoutInstance) {
-                if (createErr) {
-                    self.showError($t("PayPal Checkout could not be initialized. Please contact the store owner."));
-                    console.error('paypalCheckout error', createErr);
-                    return;
-                }
-
-                var paypalPayment = this.config.paypal,
-                    onPaymentMethodReceived = this.config.onPaymentMethodReceived,
-                    style = {
-                        color: this.getColor(),
-                        shape: this.getShape(),
-                        layout: this.getLayout(),
-                        size: this.getSize()
-                    },
-                    funding = {
-                        allowed: [],
-                        disallowed: []
-                    };
-
-                if (this.getLabel()) {
-                    style.label = this.getLabel();
-                }
-                if (this.getBranding()) {
-                    style.branding = this.getBranding();
-                }
-                if (this.getFundingIcons()) {
-                    style.fundingicons = this.getFundingIcons();
-                }
-
-                if (this.config.offerCredit === true) {
-                    paypalPayment.offerCredit = true;
-                    style.label = "credit";
-                    style.color = "darkblue";
-                    style.layout = "horizontal";
-                    funding.allowed.push(paypal.FUNDING.CREDIT);
-                } else {
-                    paypalPayment.offerCredit = false;
-                    funding.disallowed.push(paypal.FUNDING.CREDIT);
-                }
-
-                // Disabled function options
-                var disabledFunding = this.getDisabledFunding();
-                if (true === disabledFunding.card) {
-                    funding.disallowed.push(paypal.FUNDING.CARD);
-                }
-                if (true === disabledFunding.elv) {
-                    funding.disallowed.push(paypal.FUNDING.ELV);
-                }
-
-                // Render
-                this.config.paypalInstance = paypalCheckoutInstance;
-                var events = this.events;
-
-                $('#' + this.config.buttonId).html('');
-                paypal.Button.render({
-                    env: this.getEnvironment(),
-                    style: style,
-                    commit: true,
-                    funding: funding,
-                    locale: this.config.paypal.locale,
-
-                    payment: function () {
-                        return paypalCheckoutInstance.createPayment(paypalPayment);
-                    },
-
-                    onCancel: function (data) {
-                        console.log('checkout.js payment cancelled', JSON.stringify(data, 0, 2));
-
-                        if (typeof events.onCancel === 'function') {
-                            events.onCancel();
-                        }
-                    },
-
-                    onError: function (err) {
-                        self.showError($t("PayPal Checkout could not be initialized. Please contact the store owner."));
-                        this.config.paypalInstance = null;
-                        console.error('Paypal checkout.js error', err);
-
-                        if (typeof events.onError === 'function') {
-                            events.onError(err);
-                        }
-                    }.bind(this),
-
-                    onClick: function(data) {
-                        if (typeof events.onClick === 'function') {
-                            events.onClick(data);
-                        }
-                    },
-
-                    /**
-                     * Pass the payload (and payload.nonce) through to the implementation's onPaymentMethodReceived method
-                     * @param data
-                     * @param actions
-                     */
-                    onAuthorize: function (data, actions) {
-                        return paypalCheckoutInstance.tokenizePayment(data)
-                            .then(function (payload) {
-                                onPaymentMethodReceived(payload);
-                            });
-                    }
-                }, '#' + this.config.buttonId).then(function () {
-                    this.enableButton();
-                    if (typeof this.config.onPaymentMethodError === 'function') {
-                        this.config.onPaymentMethodError();
-                    }
-                }.bind(this)).then(function (data) {
-                    if (typeof events.onRender === 'function') {
-                        events.onRender(data);
-                    }
-                });
             }.bind(this));
         },
 


### PR DESCRIPTION
The default PayPal Express Checkout payment method wasn't working with our Braintree Credit Card payment method. This means the PayPal button was not appearing on the checkout page when our Braintree Credit Card payment method has been enabled. So implemented this fix.