### PR TITLE
Error when disabled all Local Payment Methods

### DIFF
--- a/Model/Lpm/Config.php
+++ b/Model/Lpm/Config.php
@@ -129,6 +129,10 @@ class Config extends \Magento\Payment\Gateway\Config\Config
         );
 
         foreach ($allowedMethods as $allowedMethod) {
+            if (! $allowedMethod) {
+                continue;
+            }
+            
             $this->allowedMethods[] = [
                 'method' => $allowedMethod,
                 'label' => constant('self::LABEL_'.strtoupper($allowedMethod)),


### PR DESCRIPTION
The error occurs when all payment methods are disabled in "Allowed Payment Methods" field of "Local Payment Methods" section