### PR TITLE
fix: adding variable check to getShippingAddress method

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/paypal.js
+++ b/view/frontend/web/js/view/payment/method-renderer/paypal.js
@@ -322,12 +322,25 @@ define([
          * @returns {Object}
          */
         getShippingAddress: function () {
-            var address = quote.shippingAddress();
+
+            var line0, line1, address;
+
+            address = quote.shippingAddress();
+
+            if(!_.isUndefined(address.street) && _.isArray(address.street)) {
+                line0 = !_.isUndefined(address.street[0]) ? address.street[0] : "";
+                address.street.shift();
+                line1 = address.street.slice(0, 2).filter(Boolean).join(' ');
+            }
+
+            if(!_.isUndefined(address.street) && _.isString(address.street)) {
+                line0 = address.street;
+            }
 
             return {
-                recipientName: address.firstname + ' ' + address.lastname,
-                line1: address.street[0],
-                line2: typeof address.street[2] === 'undefined' ? address.street[1] : address.street[1] + ' ' + address.street[2],
+                recipientName: [address.firstname, address.lastname].filter(Boolean).join(' '),
+                line1: line0,
+                line2: line1,
                 city: address.city,
                 countryCode: address.countryId,
                 postalCode: address.postcode,


### PR DESCRIPTION
adding variable check to getShippingAddress method in case the values are missing due async nature of checkout and unknown module load order. If this issue happens checkout is broken for customers and endless loader is displayed . This can be replicated randomly with default checkout if network is tampered or random 3rd party extensions try to request payment methods on first step (eq: checkout layout is customised by designers) , definitely with any OneStepCheckout  like scenarios when your modules can be exposed when data is not entered on previous steps. 

### issue

 on some page loads this method gives errors due the fact that quote.shippingAddress() can be  one of the following dependant of init time or module load order: undefined, null, empty array, partial filled array, empty address object, partially filled address object, fully filled address object . 

> Uncaught TypeError: Cannot read property '0' of undefined
>     at UiClass.getShippingAddress (paypal.js:329)
>     at UiClass.getPayPalConfig (paypal.js:310)
>     at UiClass.initClientConfig (paypal.js:187)
>     at UiClass.initObservable (paypal.js:134)
>     at UiClass.initObservable (wrapper.js:109)
>     at UiClass.initialize (element.js:104)
>     at UiClass.initialize (wrapper.js:109)
>     at UiClass._super (wrapper.js:106)
>     at UiClass.initialize (default.js:62)
>     at UiClass.initialize (wrapper.js:109)
>     at UiClass._super (wrapper.js:106)
>     at UiClass.extendingObj.initialize (default.js:21)
>     at UiClass.initialize (wrapper.js:109)
>     at new UiClass (class.js:49)
>     at Object.initComponent (layout.js:137)
>     at fire (jquery.js:3238)

### solution

is to add validation for variables before usage as street can be undefined , string , array (0 - 4 elements) and name variables can be empty with no values .

### remarks

this only adds variables and does not evaluate the reasoning behind sending/setting empty variables
