### PR TITLE
v3.4.x [PBSD-32] Fixed Billing Address from PayPal was not getting populated issue.

### DIFF
--- a/Block/Paypal/Button.php
+++ b/Block/Paypal/Button.php
@@ -246,4 +246,12 @@ class Button extends Template implements ShortcutInterface
     {
         return $this->getIsCart() ? 'cart' : 'minicart';
     }
+
+    /**
+     * @return bool
+     */
+    public function isRequiredBillingAddress(): bool
+    {
+        return (bool) $this->config->isRequiredBillingAddress();
+    }
 }

--- a/Model/Paypal/Helper/QuoteUpdater.php
+++ b/Model/Paypal/Helper/QuoteUpdater.php
@@ -19,6 +19,7 @@ use Magento\Quote\Model\Quote\Address;
 
 /**
  * Class QuoteUpdater
+ * @package Magento\Braintree\Model\Paypal\Helper
  */
 class QuoteUpdater extends AbstractHelper
 {
@@ -41,13 +42,14 @@ class QuoteUpdater extends AbstractHelper
      * @var ResourceConnection
      */
     private $resource;
+
     /**
      * @var Region
      */
     private $region;
 
     /**
-     * Constructor
+     * QuoteUpdater constructor.
      *
      * @param Config $config
      * @param CartRepositoryInterface $quoteRepository
@@ -170,8 +172,8 @@ class QuoteUpdater extends AbstractHelper
     private function updateShippingAddress(Quote $quote, array $details)
     {
         $shippingAddress = $quote->getShippingAddress();
-        $shippingAddress->setLastname($details['lastName']);
-        $shippingAddress->setFirstname($details['firstName']);
+        $shippingAddress->setFirstname($details['shippingAddress']['recipientFirstName']);
+        $shippingAddress->setLastname($details['shippingAddress']['recipientLastName']);
         $shippingAddress->setEmail($details['email']);
 
         $shippingAddress->setCollectShippingRates(true);
@@ -181,7 +183,7 @@ class QuoteUpdater extends AbstractHelper
         // PayPal's address supposes not saving against customer account
         $shippingAddress->setSaveInAddressBook(false);
         $shippingAddress->setSameAsBilling(false);
-        $shippingAddress->unsCustomerAddressId();
+        $shippingAddress->setCustomerAddressId(null);
     }
 
     /**
@@ -194,22 +196,15 @@ class QuoteUpdater extends AbstractHelper
     private function updateBillingAddress(Quote $quote, array $details)
     {
         $billingAddress = $quote->getBillingAddress();
-        $billingAddress->setFirstname($details['firstName']);
-        $billingAddress->setLastname($details['lastName']);
+        $billingAddress->setFirstname($details['shippingAddress']['recipientFirstName']);
+        $billingAddress->setLastname($details['shippingAddress']['recipientLastName']);
         $billingAddress->setEmail($details['email']);
 
-        if ($this->config->isRequiredBillingAddress()) {
-            $this->updateAddressData($billingAddress, $details['billingAddress']);
+        if ($this->config->isRequiredBillingAddress() && !empty($details['billingAddress'])) {
+            $billingAddress->setFirstname($details['firstName']);
+            $billingAddress->setLastname($details['lastName']);
 
-            if (!empty($details['billingAddress']['firstName'])) {
-                $billingAddress->setFirstname($details['firstName']);
-            }
-            if (!empty($details['billingAddress']['lastName'])) {
-                $billingAddress->setLastname($details['lastName']);
-            }
-            if (!empty($details['billingAddress']['email'])) {
-                $billingAddress->setEmail($details['email']);
-            }
+            $this->updateAddressData($billingAddress, $details['billingAddress']);
         } else {
             $this->updateAddressData($billingAddress, $details['shippingAddress']);
         }
@@ -217,7 +212,7 @@ class QuoteUpdater extends AbstractHelper
         // PayPal's address supposes not saving against customer account
         $billingAddress->setSaveInAddressBook(false);
         $billingAddress->setSameAsBilling(false);
-        $billingAddress->unsCustomerAddressId();
+        $billingAddress->setCustomerAddressId(null);
     }
 
     /**
@@ -243,9 +238,12 @@ class QuoteUpdater extends AbstractHelper
         $address->setCountryId($addressData['countryCodeAlpha2']);
         $address->setPostcode($addressData['postalCode']);
 
+        if (!empty($addressData['telephone'])) {
+            $address->setTelephone($addressData['telephone']);
+        }
+
         // PayPal's address supposes not saving against customer account
         $address->setSaveInAddressBook(false);
         $address->setSameAsBilling(false);
-        $address->setCustomerAddressId(null);
     }
 }

--- a/Model/Ui/PayPal/ConfigProvider.php
+++ b/Model/Ui/PayPal/ConfigProvider.php
@@ -37,6 +37,7 @@ class ConfigProvider implements ConfigProviderInterface
 
     /**
      * ConfigProvider constructor.
+     *
      * @param Config $config
      * @param CreditConfig $creditConfig
      * @param ResolverInterface $resolver
@@ -74,7 +75,8 @@ class ConfigProvider implements ConfigProviderInterface
                         'shape' => $this->config->getButtonShape(Config::BUTTON_AREA_CHECKOUT),
                         'size' => $this->config->getButtonSize(Config::BUTTON_AREA_CHECKOUT),
                         'color' => $this->config->getButtonColor(Config::BUTTON_AREA_CHECKOUT)
-                    ]
+                    ],
+                    'isRequiredBillingAddress' => (bool) $this->config->isRequiredBillingAddress()
                 ],
 
                 self::PAYPAL_CREDIT_CODE => [
@@ -90,7 +92,8 @@ class ConfigProvider implements ConfigProviderInterface
                         'shape' => $this->config->getButtonShape(Config::BUTTON_AREA_CHECKOUT),
                         'size' => $this->config->getButtonSize(Config::BUTTON_AREA_CHECKOUT),
                         'color' => $this->config->getButtonColor(Config::BUTTON_AREA_CHECKOUT)
-                    ]
+                    ],
+                    'isRequiredBillingAddress' => (bool) $this->config->isRequiredBillingAddress()
                 ]
             ]
         ];

--- a/view/frontend/templates/paypal/button.phtml
+++ b/view/frontend/templates/paypal/button.phtml
@@ -31,7 +31,8 @@ $config = [
         'shape' => $block->getButtonShape(),
         'size' => $block->getButtonSize(),
         'color' => $block->getButtonColor(),
-        'disabledFunding' => $block->getDisabledFunding()
+        'disabledFunding' => $block->getDisabledFunding(),
+        'isRequiredBillingAddress' => $block->isRequiredBillingAddress()
     ]
 ];
 if ($block->isCreditActive()) {
@@ -45,7 +46,8 @@ if ($block->isCreditActive()) {
             'offerCredit' => true,
             'shape' => $block->getButtonShape(),
             'size' => $block->getButtonSize(),
-            'color' => 'darkblue'
+            'color' => 'darkblue',
+            'isRequiredBillingAddress' => $block->isRequiredBillingAddress()
         ]
     ];
 }

--- a/view/frontend/templates/paypal/product_page.phtml
+++ b/view/frontend/templates/paypal/product_page.phtml
@@ -27,7 +27,8 @@ $config = [
         'shape' => $block->getButtonShape(),
         'size' => $block->getButtonSize(),
         'color' => $block->getButtonColor(),
-        'disabledFunding' => $block->getDisabledFunding()
+        'disabledFunding' => $block->getDisabledFunding(),
+        'isRequiredBillingAddress' => $block->isRequiredBillingAddress()
     ]
 ];
 
@@ -43,6 +44,7 @@ if ($block->isCreditActive()) {
             'shape' => $block->getButtonShape(),
             'size' => $block->getButtonSize(),
             'color' => 'darkblue',
+            'isRequiredBillingAddress' => $block->isRequiredBillingAddress()
         ]
     ];
 }

--- a/view/frontend/web/js/view/payment/method-renderer/paypal.js
+++ b/view/frontend/web/js/view/payment/method-renderer/paypal.js
@@ -218,10 +218,18 @@ define([
         beforePlaceOrder: function (data) {
             this.setPaymentMethodNonce(data.nonce);
 
-            if (quote.shippingAddress() === quote.billingAddress()) {
-                selectBillingAddress(quote.shippingAddress());
+            if (this.isRequiredBillingAddress() === true || quote.billingAddress() === null) {
+                if (typeof data.details.billingAddress !== 'undefined') {
+                    this.setBillingAddress(data.details, data.details.billingAddress);
+                } else {
+                    this.setBillingAddress(data.details, data.details.shippingAddress);
+                }
             } else {
-                selectBillingAddress(quote.billingAddress());
+                if (quote.shippingAddress() === quote.billingAddress()) {
+                    selectBillingAddress(quote.shippingAddress());
+                } else {
+                    selectBillingAddress(quote.billingAddress());
+                }
             }
 
             this.customerEmail(data.details.email);
@@ -252,6 +260,14 @@ define([
                 Braintree.setup();
                 this.enableButton();
             }
+        },
+
+        /**
+         * Is Billing Address required from PayPal side
+         * @returns {exports.isRequiredBillingAddress|(function())|boolean}
+         */
+        isRequiredBillingAddress: function () {
+            return window.checkoutConfig.payment[this.getCode()].isRequiredBillingAddress;
         },
 
         /**


### PR DESCRIPTION
The billing address from PayPal was not getting populated in the Magento order even after selecting the **Require Customer's Billing Address** configuration option value as **YES** from the admin panel.