### PR TITLE
[PBSD-32] Fixed Billing Address from PayPal was not getting populated issue

### DIFF
--- a/Block/Paypal/Button.php
+++ b/Block/Paypal/Button.php
@@ -246,4 +246,12 @@ class Button extends Template implements ShortcutInterface
     {
         return $this->getIsCart() ? 'cart' : 'minicart';
     }
+
+    /**
+     * @return bool
+     */
+    public function isRequiredBillingAddress(): bool
+    {
+        return (bool) $this->config->isRequiredBillingAddress();
+    }
 }

--- a/Model/Paypal/Helper/QuoteUpdater.php
+++ b/Model/Paypal/Helper/QuoteUpdater.php
@@ -19,6 +19,7 @@ use Magento\Quote\Model\Quote\Address;
 
 /**
  * Class QuoteUpdater
+ * @package Magento\Braintree\Model\Paypal\Helper
  */
 class QuoteUpdater extends AbstractHelper
 {
@@ -41,13 +42,14 @@ class QuoteUpdater extends AbstractHelper
      * @var ResourceConnection
      */
     private $resource;
+
     /**
      * @var Region
      */
     private $region;
 
     /**
-     * Constructor
+     * QuoteUpdater constructor.
      *
      * @param Config $config
      * @param CartRepositoryInterface $quoteRepository
@@ -170,8 +172,8 @@ class QuoteUpdater extends AbstractHelper
     private function updateShippingAddress(Quote $quote, array $details)
     {
         $shippingAddress = $quote->getShippingAddress();
-        $shippingAddress->setLastname($details['lastName']);
-        $shippingAddress->setFirstname($details['firstName']);
+        $shippingAddress->setFirstname($details['shippingAddress']['recipientFirstName']);
+        $shippingAddress->setLastname($details['shippingAddress']['recipientLastName']);
         $shippingAddress->setEmail($details['email']);
 
         $shippingAddress->setCollectShippingRates(true);
@@ -181,7 +183,7 @@ class QuoteUpdater extends AbstractHelper
         // PayPal's address supposes not saving against customer account
         $shippingAddress->setSaveInAddressBook(false);
         $shippingAddress->setSameAsBilling(false);
-        $shippingAddress->unsCustomerAddressId();
+        $shippingAddress->setCustomerAddressId(null);
     }
 
     /**
@@ -194,22 +196,15 @@ class QuoteUpdater extends AbstractHelper
     private function updateBillingAddress(Quote $quote, array $details)
     {
         $billingAddress = $quote->getBillingAddress();
-        $billingAddress->setFirstname($details['firstName']);
-        $billingAddress->setLastname($details['lastName']);
+        $billingAddress->setFirstname($details['shippingAddress']['recipientFirstName']);
+        $billingAddress->setLastname($details['shippingAddress']['recipientLastName']);
         $billingAddress->setEmail($details['email']);
 
-        if ($this->config->isRequiredBillingAddress()) {
-            $this->updateAddressData($billingAddress, $details['billingAddress']);
+        if ($this->config->isRequiredBillingAddress() && !empty($details['billingAddress'])) {
+            $billingAddress->setFirstname($details['firstName']);
+            $billingAddress->setLastname($details['lastName']);
 
-            if (!empty($details['billingAddress']['firstName'])) {
-                $billingAddress->setFirstname($details['firstName']);
-            }
-            if (!empty($details['billingAddress']['lastName'])) {
-                $billingAddress->setLastname($details['lastName']);
-            }
-            if (!empty($details['billingAddress']['email'])) {
-                $billingAddress->setEmail($details['email']);
-            }
+            $this->updateAddressData($billingAddress, $details['billingAddress']);
         } else {
             $this->updateAddressData($billingAddress, $details['shippingAddress']);
         }
@@ -217,7 +212,7 @@ class QuoteUpdater extends AbstractHelper
         // PayPal's address supposes not saving against customer account
         $billingAddress->setSaveInAddressBook(false);
         $billingAddress->setSameAsBilling(false);
-        $billingAddress->unsCustomerAddressId();
+        $billingAddress->setCustomerAddressId(null);
     }
 
     /**
@@ -243,9 +238,12 @@ class QuoteUpdater extends AbstractHelper
         $address->setCountryId($addressData['countryCodeAlpha2']);
         $address->setPostcode($addressData['postalCode']);
 
+        if (!empty($addressData['telephone'])) {
+            $address->setTelephone($addressData['telephone']);
+        }
+
         // PayPal's address supposes not saving against customer account
         $address->setSaveInAddressBook(false);
         $address->setSameAsBilling(false);
-        $address->setCustomerAddressId(null);
     }
 }

--- a/Model/Ui/PayPal/ConfigProvider.php
+++ b/Model/Ui/PayPal/ConfigProvider.php
@@ -74,7 +74,8 @@ class ConfigProvider implements ConfigProviderInterface
                         'shape' => $this->config->getButtonShape(Config::BUTTON_AREA_CHECKOUT),
                         'size' => $this->config->getButtonSize(Config::BUTTON_AREA_CHECKOUT),
                         'color' => $this->config->getButtonColor(Config::BUTTON_AREA_CHECKOUT)
-                    ]
+                    ],
+                    'isRequiredBillingAddress' => (bool) $this->config->isRequiredBillingAddress()
                 ],
 
                 self::PAYPAL_CREDIT_CODE => [
@@ -90,7 +91,8 @@ class ConfigProvider implements ConfigProviderInterface
                         'shape' => $this->config->getButtonShape(Config::BUTTON_AREA_CHECKOUT),
                         'size' => $this->config->getButtonSize(Config::BUTTON_AREA_CHECKOUT),
                         'color' => $this->config->getButtonColor(Config::BUTTON_AREA_CHECKOUT)
-                    ]
+                    ],
+                    'isRequiredBillingAddress' => (bool) $this->config->isRequiredBillingAddress()
                 ]
             ]
         ];

--- a/view/frontend/templates/paypal/button.phtml
+++ b/view/frontend/templates/paypal/button.phtml
@@ -31,7 +31,8 @@ $config = [
         'shape' => $block->getButtonShape(),
         'size' => $block->getButtonSize(),
         'color' => $block->getButtonColor(),
-        'disabledFunding' => $block->getDisabledFunding()
+        'disabledFunding' => $block->getDisabledFunding(),
+        'isRequiredBillingAddress' => $block->isRequiredBillingAddress()
     ]
 ];
 if ($block->isCreditActive()) {
@@ -45,7 +46,8 @@ if ($block->isCreditActive()) {
             'offerCredit' => true,
             'shape' => $block->getButtonShape(),
             'size' => $block->getButtonSize(),
-            'color' => 'darkblue'
+            'color' => 'darkblue',
+            'isRequiredBillingAddress' => $block->isRequiredBillingAddress()
         ]
     ];
 }

--- a/view/frontend/templates/paypal/product_page.phtml
+++ b/view/frontend/templates/paypal/product_page.phtml
@@ -27,7 +27,8 @@ $config = [
         'shape' => $block->getButtonShape(),
         'size' => $block->getButtonSize(),
         'color' => $block->getButtonColor(),
-        'disabledFunding' => $block->getDisabledFunding()
+        'disabledFunding' => $block->getDisabledFunding(),
+        'isRequiredBillingAddress' => $block->isRequiredBillingAddress()
     ]
 ];
 
@@ -43,6 +44,7 @@ if ($block->isCreditActive()) {
             'shape' => $block->getButtonShape(),
             'size' => $block->getButtonSize(),
             'color' => 'darkblue',
+            'isRequiredBillingAddress' => $block->isRequiredBillingAddress()
         ]
     ];
 }

--- a/view/frontend/web/js/paypal/button.js
+++ b/view/frontend/web/js/paypal/button.js
@@ -101,6 +101,11 @@ define(
                 },
 
                 /**
+                 * {Bool}
+                 */
+                isRequiredBillingAddress: false,
+
+                /**
                  * {Object}
                  */
                 events: {
@@ -136,6 +141,13 @@ define(
 
                 this.initCallback(data);
                 return this;
+            },
+
+            /**
+             * @returns {boolean}
+             */
+            isBillingAddressRequired: function () {
+                return this.isRequiredBillingAddress;
             },
 
             initCallback: function (data) {
@@ -207,7 +219,8 @@ define(
                         // Render
                         var actionSuccess = this.actionSuccess,
                             beforeSubmit = this.beforeSubmit,
-                            events = this.events;
+                            events = this.events,
+                            isBillingAddressRequired = this.isBillingAddressRequired();
 
                         paypal.Button.render({
                             env: this.environment,
@@ -261,17 +274,36 @@ define(
 
                                         // Map the shipping address correctly
                                         var address = payload.details.shippingAddress;
+                                        var recipientName = address.recipientName.split(" ");
                                         payload.details.shippingAddress = {
                                             streetAddress: typeof address.line2 !== 'undefined' ? address.line1.replace(/'/g, "&apos;") + " " + address.line2.replace(/'/g, "&apos;") : address.line1.replace(/'/g, "&apos;"),
                                             locality: address.city.replace(/'/g, "&apos;"),
                                             postalCode: address.postalCode,
                                             countryCodeAlpha2: address.countryCode,
-                                            email: payload.details.email.replace(/'/g, "&apos;"),
-                                            firstname: payload.details.firstName.replace(/'/g, "&apos;"),
-                                            lastname: payload.details.lastName.replace(/'/g, "&apos;"),
+                                            recipientFirstName: recipientName[0].replace(/'/g, "&apos;"),
+                                            recipientLastName: recipientName[1].replace(/'/g, "&apos;"),
                                             telephone: typeof payload.details.phone !== 'undefined' ? payload.details.phone : '',
                                             region: typeof address.state !== 'undefined' ? address.state.replace(/'/g, "&apos;") : ''
                                         };
+                                        payload.details.email = payload.details.email.replace(/'/g, "&apos;");
+                                        payload.details.firstName = payload.details.firstName.replace(/'/g, "&apos;");
+                                        payload.details.lastName = payload.details.lastName.replace(/'/g, "&apos;");
+                                        if (typeof payload.details.businessName !== 'undefined') {
+                                            payload.details.businessName = payload.details.businessName.replace(/'/g, "&apos;");
+                                        }
+
+                                        // Map the billing address correctly
+                                        if (isBillingAddressRequired === true) {
+                                            var billingAddress = payload.details.billingAddress;
+                                            payload.details.billingAddress = {
+                                                streetAddress: typeof billingAddress.line2 !== 'undefined' ? billingAddress.line1.replace(/'/g, "&apos;") + " " + billingAddress.line2.replace(/'/g, "&apos;") : billingAddress.line1.replace(/'/g, "&apos;"),
+                                                locality: billingAddress.city.replace(/'/g, "&apos;"),
+                                                postalCode: billingAddress.postalCode,
+                                                countryCodeAlpha2: billingAddress.countryCode,
+                                                telephone: typeof payload.details.phone !== 'undefined' ? payload.details.phone : '',
+                                                region: typeof billingAddress.state !== 'undefined' ? billingAddress.state.replace(/'/g, "&apos;") : ''
+                                            };
+                                        }
 
                                         formBuilder.build(
                                             {

--- a/view/frontend/web/js/view/payment/method-renderer/paypal.js
+++ b/view/frontend/web/js/view/payment/method-renderer/paypal.js
@@ -230,10 +230,18 @@ define([
         beforePlaceOrder: function (data) {
             this.setPaymentMethodNonce(data.nonce);
 
-            if (quote.shippingAddress() === quote.billingAddress()) {
-                selectBillingAddress(quote.shippingAddress());
+            if (this.isRequiredBillingAddress() === true || quote.billingAddress() === null) {
+                if (typeof data.details.billingAddress !== 'undefined') {
+                    this.setBillingAddress(data.details, data.details.billingAddress);
+                } else {
+                    this.setBillingAddress(data.details, data.details.shippingAddress);
+                }
             } else {
-                selectBillingAddress(quote.billingAddress());
+                if (quote.shippingAddress() === quote.billingAddress()) {
+                    selectBillingAddress(quote.shippingAddress());
+                } else {
+                    selectBillingAddress(quote.billingAddress());
+                }
             }
 
             this.customerEmail(data.details.email);
@@ -264,6 +272,14 @@ define([
                 Braintree.setup();
                 this.enableButton();
             }
+        },
+
+        /**
+         * Is Billing Address required from PayPal side
+         * @returns {exports.isRequiredBillingAddress|(function())|boolean}
+         */
+        isRequiredBillingAddress: function () {
+            return window.checkoutConfig.payment[this.getCode()].isRequiredBillingAddress;
         },
 
         /**


### PR DESCRIPTION
The billing address from PayPal was not getting populated in the Magento order even after selecting the **Require Customer's Billing Address** configuration option value as **YES** from the admin panel.