### PR TITLE
[BUG-1] TypeError: explode() expects parameter 2 to be string, null g…

### DIFF
--- a/Model/Lpm/Config.php
+++ b/Model/Lpm/Config.php
@@ -120,13 +120,14 @@ class Config extends \Magento\Payment\Gateway\Config\Config
      */
     public function getAllowedMethods(): array
     {
-        $allowedMethods = explode(
-            ',',
-            $this->getValue(
-                self::KEY_ALLOWED_METHODS,
-                $this->storeConfigResolver->getStoreId()
-            )
-        );
+        $allowedMethodsValue = $this->getValue(self::KEY_ALLOWED_METHODS, $this->storeConfigResolver->getStoreId());
+
+        if (!$allowedMethodsValue) {
+            $this->allowedMethods = [];
+            return $this->allowedMethods;
+        }
+
+        $allowedMethods = explode(',', $allowedMethodsValue);
 
         foreach ($allowedMethods as $allowedMethod) {
             $this->allowedMethods[] = [


### PR DESCRIPTION
…iven in vendor/paypal/module-braintree-core/Model/Lpm/Config.php

Magento 2.4

Steps to reproduce:
1) add a product to the cart
2) go to the checkout cart page
3) observe:
Estimate Shipping and Tax
TypeError: explode() expects parameter 2 to be string, null given in /var/www/source/vendor/paypal/module-braintree-core/Model/Lpm/Config.php:125 Stack trace: #0 /var/www/source/vendor/paypal/module-braintree-core/Model/Lpm/Config.php(125): explode(',', NULL) #1 /var/www/source/vendor/magento/framework/Interception/Interceptor.php(58): PayPal\Braintree\Model\Lpm\Config->getAllowedMethods()