### PR TITLE
Fixed LPM - TypeError: explode() expects parameter 2 to be string, null given error (v4.0.6)

### DIFF
--- a/Model/Lpm/Config.php
+++ b/Model/Lpm/Config.php
@@ -13,9 +13,10 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\View\Asset\Repository;
 
 /**
- * Class Config
- *
  * Provide configuration for LPMs
+ *
+ * Class Config
+ * @package Magento\Braintree\Model\Lpm
  */
 class Config extends \Magento\Payment\Gateway\Config\Config
 {
@@ -81,8 +82,14 @@ class Config extends \Magento\Payment\Gateway\Config\Config
     private $assetRepo;
 
     /**
+     * Config constructor.
+     * @param BraintreeAdapter $adapter
+     * @param BraintreeConfig $braintreeConfig
      * @param StoreConfigResolver $storeConfigResolver
-     * {@inheritDoc}
+     * @param Repository $assetRepo
+     * @param ScopeConfigInterface $scopeConfig
+     * @param null $methodCode
+     * @param $pathPattern
      */
     public function __construct(
         BraintreeAdapter $adapter,
@@ -120,13 +127,16 @@ class Config extends \Magento\Payment\Gateway\Config\Config
      */
     public function getAllowedMethods(): array
     {
-        $allowedMethods = explode(
-            ',',
-            $this->getValue(
-                self::KEY_ALLOWED_METHODS,
-                $this->storeConfigResolver->getStoreId()
-            )
+        $allowedMethodsValue = $this->getValue(
+            self::KEY_ALLOWED_METHODS,
+            $this->storeConfigResolver->getStoreId()
         );
+
+        if (is_null($allowedMethodsValue)) {
+            return [];
+        }
+
+        $allowedMethods = explode(',', $allowedMethodsValue);
 
         foreach ($allowedMethods as $allowedMethod) {
             $this->allowedMethods[] = [

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -172,14 +172,14 @@
                             <frontend_model>Magento\Braintree\Block\Adminhtml\Form\Field\Validation</frontend_model>
                         </field>
                     </group>
-                    <group id="braintree_advanced" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="20">
+                    <group id="braintree_advanced" translate="label" showInDefault="1" showInWebsite="1" showInStore="0" sortOrder="20">
                         <label>Advanced Braintree Settings</label>
                         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
                         <field id="braintree_cc_vault_title" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
                             <label>Vault Title</label>
                             <config_path>payment/braintree_cc_vault/title</config_path>
                         </field>
-                        <field id="merchant_account_id" translate="label" sortOrder="25" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <field id="merchant_account_id" translate="label" sortOrder="25" showInDefault="1" showInWebsite="1" showInStore="0">
                             <label>Merchant Account ID</label>
                             <comment>If you don't specify the merchant account to use to process a transaction, Braintree will process it using your default merchant account.</comment>
                             <config_path>payment/braintree/merchant_account_id</config_path>
@@ -349,18 +349,18 @@
                             </comment>
                         </field>
                     </group>
-                    <group id="braintree_local_payment" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="42">
+                    <group id="braintree_local_payment" translate="label" showInDefault="1" showInWebsite="1" showInStore="0" sortOrder="42">
                         <label>Local Payment Methods</label>
                         <comment>
                             All payments made with a Local Payment Method will be treated as an "Intent Sale" payment action.
                         </comment>
                         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
-                        <field id="active" translate="label" type="select" sortOrder="0" showInDefault="1" showInWebsite="1">
+                        <field id="active" translate="label" type="select" sortOrder="0" showInDefault="1" showInWebsite="1" showInStore="0">
                             <label>Enable Local Payment Methods</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/braintree_local_payment/active</config_path>
                         </field>
-                        <field id="title" translate="label" type="text" sortOrder="5" showInDefault="1" showInWebsite="1">
+                        <field id="title" translate="label" type="text" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="0">
                             <label>Title</label>
                             <config_path>payment/braintree_local_payment/title</config_path>
                             <validate>required-entry</validate>
@@ -368,7 +368,7 @@
                                 <field id="active">1</field>
                             </depends>
                         </field>
-                        <field id="allowed_methods" translate="label" type="multiselect" sortOrder="10" showInDefault="1" showInWebsite="1">
+                        <field id="allowed_methods" translate="label" type="multiselect" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">
                             <label>Allowed Payment Methods</label>
                             <comment>
                                 Any particular payment method will only be visible to customers who's billing address is


### PR DESCRIPTION
**Fixed:**
`TypeError: explode() expects parameter 2 to be string, null given in /var/www/source/vendor/paypal/module-braintree-core/Model/Lpm/Config.php:125`