### PR TITLE
Blank checkout page if empty KEY_ALLOWED_METHODS

### DIFF
--- a/Model/Lpm/Config.php
+++ b/Model/Lpm/Config.php
@@ -120,13 +120,13 @@ class Config extends \Magento\Payment\Gateway\Config\Config
      */
     public function getAllowedMethods(): array
     {
-        $allowedMethods = explode(
-            ',',
-            $this->getValue(
-                self::KEY_ALLOWED_METHODS,
-                $this->storeConfigResolver->getStoreId()
-            )
-        );
+        $configuredMethods = $this->getValue(self::KEY_ALLOWED_METHODS, $this->storeConfigResolver->getStoreId()) ?? [];
+        
+        if (empty($configuredMethods)) {
+            return []; //or throw informative exeption, otherwise we got blank page on checkout
+        }
+        
+        $allowedMethods = explode(',', $configuredMethods);
 
         foreach ($allowedMethods as $allowedMethod) {
             $this->allowedMethods[] = [


### PR DESCRIPTION
Fixes an error
```
TypeError: explode() expects parameter 2 to be string, null given in vendor/paypal/module-braintree-core/Model/Lpm/Config.php:125
Stack trace:
```