### PR TITLE
Remove Deprecated Coinbase Payment Method from Report

### DIFF
--- a/Ui/Component/Report/Listing/Column/PaymentType.php
+++ b/Ui/Component/Report/Listing/Column/PaymentType.php
@@ -47,7 +47,6 @@ class PaymentType implements OptionSourceInterface
         // @codingStandardsIgnoreStart
         return [
             PaymentInstrumentType::PAYPAL_ACCOUNT => __(PaymentInstrumentType::PAYPAL_ACCOUNT),
-            PaymentInstrumentType::COINBASE_ACCOUNT => __(PaymentInstrumentType::COINBASE_ACCOUNT),
             PaymentInstrumentType::EUROPE_BANK_ACCOUNT => __(PaymentInstrumentType::EUROPE_BANK_ACCOUNT),
             PaymentInstrumentType::CREDIT_CARD => __(PaymentInstrumentType::CREDIT_CARD),
             PaymentInstrumentType::APPLE_PAY_CARD => __(PaymentInstrumentType::APPLE_PAY_CARD),


### PR DESCRIPTION
https://github.com/braintree/braintree_php/blob/master/CHANGELOG.md#400

Coinbase Payment method has been deprecated and removed from Braintree lib, but not removed from the report UI 