### PR TITLE
Fix add/remove promo code on paypal review page

### DIFF
--- a/Controller/Paypal/Review.php
+++ b/Controller/Paypal/Review.php
@@ -60,7 +60,7 @@ class Review extends AbstractAction
         $quote = $this->checkoutSession->getQuote();
 
         try {
-            if (empty($requestData) || $requestData === null) {
+            if (is_array($requestData) === false) {
                 throw new LocalizedException(__('Malformed request data. This may be caused by special characters. Please try again'));
             }
             $this->validateQuote($quote);


### PR DESCRIPTION
Problem: Can't add or remove promo codes on the paypal review page /braintree/paypal/review/
Steps: 
- Setup a coupon code based promotion/cart price rule
- Add an item to the cart
- Checkout with Paypal
- On the final review page /braintree/paypal/review/ attempt to use the coupon
 
Expected Result: coupon is applied
Actual result: user is returned to the cart page with the error 'Malformed request data. This may be caused by special characters. Please try again'

See #79 for some extra history and context