### PR TITLE
Fix Applying Coupon Without Payment Method Chosen

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/paypal.js
+++ b/view/frontend/web/js/view/payment/method-renderer/paypal.js
@@ -138,6 +138,10 @@ define([
                     self.grandTotalAmount = quote.totals()['base_grand_total'];
                     var methodCode = quote.paymentMethod();
 
+                    if (!methodCode) {
+                        return;
+                    }
+                    
                     if (methodCode['method'] === 'braintree_paypal' || methodCode['method'] === 'braintree_paypal_vault') {
                         self.reInitPayPal();
                     }


### PR DESCRIPTION
## Problem
If the customer attempts to apply or remove a coupon code before selecting a payment method, an error is thrown for trying to access a property on a null value.

![Screenshot 2021-03-25 at 10 15 30](https://user-images.githubusercontent.com/40261741/112456847-0c1d9780-8d53-11eb-9506-af92ee28fd70.png)

## Expected Result
The customer can apply and remove the coupon code successfully without having to first select a payment method.

## Actual Result
The aforementioned error is thrown and the checkout loads indefinitely.

## Steps to Reproduce
1. Create a cart price rule with a coupon code
2. Add products to the cart
3. Proceed through the checkout to the payment step
4. Apply/remove the coupon code _before_ selecting a payment method
