### PR TITLE
Replace ES6 spread and arrow function usage

### DIFF
--- a/view/frontend/web/js/view/payment/3d-secure.js
+++ b/view/frontend/web/js/view/payment/3d-secure.js
@@ -47,7 +47,7 @@ define([
                 }
 
                 return c.split('').map(function (a) {
-                    return '\\u' + a.charCodeAt().toString(16).padStart(4, '0')
+                    return '\\u' + a.charCodeAt().toString(16).padStart(4, '0');
                 }).join('');
             }).join('');
         },

--- a/view/frontend/web/js/view/payment/3d-secure.js
+++ b/view/frontend/web/js/view/payment/3d-secure.js
@@ -48,7 +48,7 @@ define([
 
                 return c.split('').map(function (a) {
                     return '\\u' + a.charCodeAt().toString(16).padStart(4, '0')
-                });
+                }).join('');
             }).join('');
         },
 

--- a/view/frontend/web/js/view/payment/3d-secure.js
+++ b/view/frontend/web/js/view/payment/3d-secure.js
@@ -41,7 +41,15 @@ define([
          * @returns {string}
          */
         escapeNonAsciiCharacters: function (str) {
-            return [...str].map(c => /^[\x00-\x7F]$/.test(c) ? c : c.split("").map(a => "\\u" + a.charCodeAt().toString(16).padStart(4, "0")).join("")).join("");
+            return str.split('').map(function (c) {
+                if (/^[\x00-\x7F]$/.test(c)) {
+                    return c;
+                }
+
+                return c.split('').map(function (a) {
+                    return '\\u' + a.charCodeAt().toString(16).padStart(4, '0')
+                });
+            }).join('');
         },
 
         /**


### PR DESCRIPTION
Remove usage of ES6 object spread and arrow functions for IE11 compatibility. This module can be installed on Magento 2.3 which has browser support for Internet Explorer 11 as per [Magento DevDocs](https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements.html#supported-browsers).