### PR TITLE
Changed PayPal Credit APR to 21.9% as requested

### DIFF
--- a/view/frontend/web/template/credit/calculator.html
+++ b/view/frontend/web/template/credit/calculator.html
@@ -37,12 +37,12 @@
     </div>
 
     <div class="ppcreditcalc-legal">
-        <p><!-- ko i18n: 'If you are approved for a credit limit with PayPal Credit and use it for future purchases, the APR for those purchases won’t be more than 19.9% and may be even lower.' --><!-- /ko --></p>
+        <p><!-- ko i18n: 'If you are approved for a credit limit with PayPal Credit and use it for future purchases, the APR for those purchases won’t be more than 21.9% and may be even lower.' --><!-- /ko --></p>
 
         <p>
             <strong><!-- ko i18n: 'Representative Example:' --><!-- /ko --></strong>
-            <br /><!-- ko i18n: 'Purchase Rate: 19.9% p.a. (variable)' --><!-- /ko -->
-            <br /><!-- ko i18n: 'Representative: 19.9% APR (variable)' --><!-- /ko -->
+            <br /><!-- ko i18n: 'Purchase Rate: 21.9% p.a. (variable)' --><!-- /ko -->
+            <br /><!-- ko i18n: 'Representative: 21.9% APR (variable)' --><!-- /ko -->
             <br /><!-- ko i18n: 'Assumed Credit Limit: £1,200' --><!-- /ko -->
             <br /><!-- ko i18n: 'Subject to status. Terms and Conditions apply.' --><!-- /ko -->
         </p>


### PR DESCRIPTION
PayPal Credit APR has been changed on 1st April 2021 from 19.9% to 21.9% so implemented that change.