### PR TITLE
Fix Array Keys for PayPal Express Address Updates

### DIFF
--- a/Model/Paypal/Helper/QuoteUpdater.php
+++ b/Model/Paypal/Helper/QuoteUpdater.php
@@ -167,8 +167,8 @@ class QuoteUpdater extends AbstractHelper
     private function updateShippingAddress(Quote $quote, array $details)
     {
         $shippingAddress = $quote->getShippingAddress();
-        $shippingAddress->setFirstname($details['shippingAddress']['recipientFirstName']);
-        $shippingAddress->setLastname($details['shippingAddress']['recipientLastName']);
+        $shippingAddress->setFirstname($details['shippingAddress']['firstname']);
+        $shippingAddress->setLastname($details['shippingAddress']['lastname']);
         $shippingAddress->setEmail($details['email']);
 
         $shippingAddress->setCollectShippingRates(true);
@@ -191,8 +191,8 @@ class QuoteUpdater extends AbstractHelper
     private function updateBillingAddress(Quote $quote, array $details)
     {
         $billingAddress = $quote->getBillingAddress();
-        $billingAddress->setFirstname($details['shippingAddress']['recipientFirstName']);
-        $billingAddress->setLastname($details['shippingAddress']['recipientLastName']);
+        $billingAddress->setFirstname($details['shippingAddress']['firstname']);
+        $billingAddress->setLastname($details['shippingAddress']['lastname']);
         $billingAddress->setEmail($details['email']);
 
         if ($this->config->isRequiredBillingAddress() && !empty($details['billingAddress'])) {


### PR DESCRIPTION
## Problem
Checking out with PayPal Express via the cart page results in an error due to an undefined array index.

```
Notice: Undefined index: recipientFirstName in /path/to/magento/root/vendor/gene/module-braintree/Model/Paypal/Helper/QuoteUpdater.php on line 170
```

## Expected Result
The customer is able to checkout using PayPal Express via the cart page.

## Actual Result
The aforementioned error is thrown and the transaction fails.

## Steps to Reproduce
1. Add an item to the cart
2. Navigate to the cart page
3. Attempt to pay using PayPal Express
