### PR TITLE
Update array access syntax for PHP 7.4

### DIFF
--- a/braintree_php/lib/Braintree/Digest.php
+++ b/braintree_php/lib/Braintree/Digest.php
@@ -50,8 +50,8 @@ class Digest
         $outerPad = str_repeat(chr(0x5C), 64);
 
         for ($i = 0; $i < 20; $i++) {
-            $innerPad{$i} = $keyDigest{$i} ^ $innerPad{$i};
-            $outerPad{$i} = $keyDigest{$i} ^ $outerPad{$i};
+            $innerPad[$i] = $keyDigest[$i] ^ $innerPad[$i];
+            $outerPad[$i] = $keyDigest[$i] ^ $outerPad[$i];
         }
 
         return sha1($outerPad.pack($pack, sha1($innerPad.$message)));


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate_curly_braces_array_access

> Deprecated Functionality: Array and string offset access syntax with curly braces is deprecated in /var/www/html/vendor/gene/module-braintree/braintree_php/lib/Braintree/Digest.php on line 53

Note that it would likely be a better plan to upgrade the embedded library. At least this is required for PHP v7.4 compatibility.