### PR TITLE
Resolve a PHP 7.4 deprecation warning regarding curly brace array access

### DIFF
--- a/braintree_php/lib/Braintree/Digest.php
+++ b/braintree_php/lib/Braintree/Digest.php
@@ -50,8 +50,8 @@ class Digest
         $outerPad = str_repeat(chr(0x5C), 64);
 
         for ($i = 0; $i < 20; $i++) {
-            $innerPad{$i} = $keyDigest{$i} ^ $innerPad{$i};
-            $outerPad{$i} = $keyDigest{$i} ^ $outerPad{$i};
+            $innerPad[$i] = $keyDigest[$i] ^ $innerPad[$i];
+            $outerPad[$i] = $keyDigest[$i] ^ $outerPad[$i];
         }
 
         return sha1($outerPad.pack($pack, sha1($innerPad.$message)));


### PR DESCRIPTION
Hi, on PHP 7.4 with version 4.0.7 of the module we get a deprecation warning that blocks compilation in some Magento environments. This PR resolves the deprecated syntax without any functional impacts. Please consider merging. Thank you!

Fixes:
`Deprecated Functionality: Array and string offset access syntax with curly braces is deprecated in [...]/vendor/gene/module-braintree/braintree_php/lib/Braintree/Digest.php on line 53`