### PR TITLE
Bugfix: Remove `buyer-country` from `loadPayPalSDK` as its not suppor…

### DIFF
--- a/view/frontend/web/js/paypal/button.js
+++ b/view/frontend/web/js/paypal/button.js
@@ -99,7 +99,6 @@ define(
                         } else {
                             paypalCheckoutInstance.loadPayPalSDK({
                                 components: 'buttons,messages,funding-eligibility',
-                                "buyer-country": 'US',
                                 currency: currency,
                             }, function () {
                                 this.renderPayPalButtons(buttonIds, paypalCheckoutInstance);


### PR DESCRIPTION
…ted in production mode.

- Error given from PayPal:
  ```
  throw new Error("SDK Validation error: 'Query parameter buyer-country disallowed in production env'" );

  /* Original Error:

  Query parameter buyer-country disallowed in production env (debug id: f619340b6f56b)

  */```