### PR TITLE
Fix missing billing telephone with Apple Pay

### DIFF
--- a/view/frontend/web/js/applepay/api.js
+++ b/view/frontend/web/js/applepay/api.js
@@ -338,7 +338,7 @@ define(
                             },
                             "billing_address": {
                                 "email": shippingContact.emailAddress,
-                                "telephone": '0000000000',
+                                "telephone": shippingContact.phoneNumber,
                                 "firstname": billingContact.givenName,
                                 "lastname": billingContact.familyName,
                                 "street": billingContact.addressLines,


### PR DESCRIPTION
**Steps to reproduce:**
1. Add some product to the cart
2. On the Cart page, press the "Apple Pay" button
3. Complete the order
4. Go to the order details, see Billing Address

### Expected Result
You should have your phone number both in billing and shipment addresses

### Actual Result
In the billing address, you see the 0000000000 instead of your phone number