### PR TITLE
Update 3d-secure.js

### DIFF
--- a/view/frontend/web/js/view/payment/3d-secure.js
+++ b/view/frontend/web/js/view/payment/3d-secure.js
@@ -55,7 +55,7 @@ define([
                 totalAmount = parseFloat(quote.totals()['base_grand_total']).toFixed(2),
                 billingAddress = quote.billingAddress();
 
-            if(billingAddress.regionCode != undefined && billingAddress.regionCode.length > 2) {
+            if(billingAddress.regionCode !== null && billingAddress.regionCode.length > 2) {
                 billingAddress.regionCode = undefined;
             }
 


### PR DESCRIPTION
This PR is a fix for the following issue raised on the main Magento 2 Github:

magento/magento2#34204

The javascript validation currently checks for undefined, however, if a region is not set then the value of this property is actually null and therefore throws a 'cannot read properties of null' error when reading the length.

If you have any additional questions, please let me know.