### PR TITLE
Back-port missing Content Security Policy

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
+    <policies>
+        <policy id="script-src">
+            <values>
+                <value id="www_paypal" type="host">www.paypal.com</value>
+                <value id="www_sandbox_paypal" type="host">www.sandbox.paypal.com</value>
+                <value id="www_paypal_objects" type="host">www.paypalobjects.com</value>
+                <value id="js_braintree_gateway" type="host">js.braintreegateway.com</value>
+                <value id="assets_braintree_gateway" type="host">assets.braintreegateway.com</value>
+                <value id="c_paypal" type="host">c.paypal.com</value>
+                <value id="pay_google" type="host">pay.google.com</value>
+                <value id="api_braintree_gateway" type="host">api.braintreegateway.com</value>
+                <value id="api_sandbox_braintree_gateway" type="host">api.sandbox.braintreegateway.com</value>
+                <value id="ca_braintree_gateway" type="host">client-analytics.braintreegateway.com</value>
+                <value id="ca_sandbox_braintree_gateway" type="host">client-analytics.sandbox.braintreegateway.com</value>
+            </values>
+        </policy>
+        <policy id="style-src">
+            <values>
+                <value id="unsafe_inline" type="host">unsafe-inline</value>
+            </values>
+        </policy>
+        <policy id="img-src">
+            <values>
+                <value id="www_paypal" type="host">www.paypal.com</value>
+                <value id="www_sandbox_paypal" type="host">www.sandbox.paypal.com</value>
+                <value id="b_stats_paypal" type="host">b.stats.paypal.com</value>
+                <value id="dub_stats_paypal" type="host">dub.stats.paypal.com</value>
+                <value id="assets_braintree_gateway" type="host">assets.braintreegateway.com</value>
+                <value id="c_paypal" type="host">c.paypal.com</value>
+                <value id="checkout_paypal" type="host">checkout.paypal.com</value>
+                <value id="data_image" type="host">data:</value>
+            </values>
+        </policy>
+        <policy id="child-src">
+            <values>
+                <value id="assets_braintree_gateway" type="host">assets.braintreegateway.com</value>
+                <value id="c_paypal" type="host">c.paypal.com</value>
+            </values>
+        </policy>
+        <policy id="frame-src">
+            <values>
+                <value id="www_paypal" type="host">www.paypal.com</value>
+                <value id="www_sandbox_paypal" type="host">www.sandbox.paypal.com</value>
+                <value id="c_paypal" type="host">c.paypal.com</value>
+                <value id="checkout_paypal" type="host">checkout.paypal.com</value>
+                <value id="assets_braintree_gateway" type="host">assets.braintreegateway.com</value>
+                <value id="pay_google" type="host">pay.google.com</value>
+                <value id="cardinal_commerce" type="host">*.cardinalcommerce.com</value>
+            </values>
+        </policy>
+        <policy id="connect-src">
+            <values>
+                <value id="www_paypal" type="host">www.paypal.com</value>
+                <value id="www_sandbox_paypal" type="host">www.sandbox.paypal.com</value>
+                <value id="api_braintree_gateway" type="host">api.braintreegateway.com</value>
+                <value id="api_sandbox_braintree_gateway" type="host">api.sandbox.braintreegateway.com</value>
+                <value id="ca_braintree_gateway" type="host">client-analytics.braintreegateway.com</value>
+                <value id="ca_sandbox_braintree_gateway" type="host">client-analytics.sandbox.braintreegateway.com</value>
+                <value id="braintree_api" type="host">*.braintree-api.com</value>
+            </values>
+        </policy>
+    </policies>
+</csp_whitelist>


### PR DESCRIPTION
This modules lacks a `csp_whitelist.xml` which means that the external services that it relies upon are not permitted to be used by supporting browsers. This file has been copied from version `4.2.5` of `paypal/module-braintree-core` which comes bundled with Magento Open Source.

https://devdocs.magento.com/guides/v2.3/extension-dev-guide/security/content-security-policies.html