### PR TITLE
validation and additionalvalidators are not called before executing call chain on click for applepay and googlepay

### DIFF
--- a/view/frontend/web/js/applepay/button.js
+++ b/view/frontend/web/js/applepay/button.js
@@ -73,6 +73,11 @@ define(
                         el.addEventListener('click', function (e) {
                             e.preventDefault();
 
+                            //default.js payment expects validation to be called before calling the place order chain, applepay is not the only component in the site
+                            if(!context.validate() || !context.getAdditionalValidators().validate()) {
+                                return false; 
+                            }
+                            
                             // Payment request object
                             var paymentRequest = applePayInstance.createPaymentRequest(context.getPaymentRequest());
                             if (!paymentRequest) {

--- a/view/frontend/web/js/applepay/implementations/core-checkout/method-renderer/applepay.js
+++ b/view/frontend/web/js/applepay/implementations/core-checkout/method-renderer/applepay.js
@@ -6,10 +6,12 @@ define([
     'Magento_Checkout/js/view/payment/default',
     'Magento_Checkout/js/model/quote',
     'Magento_Braintree/js/applepay/button'
+    'Magento_Checkout/js/model/payment/additional-validators'
 ], function (
     Component,
     quote,
-    button
+    button,
+    additionalValidators
 ) {
     'use strict';
 
@@ -21,6 +23,13 @@ define([
             deviceSupported: button.deviceSupported()
         },
 
+        /**
+         * Reveal additionalValidators to button.js component
+         */
+        getAdditionalValidators: function() {
+            return additionalValidators;
+        },
+        
         /**
          * Inject the apple pay button into the target element
          */

--- a/view/frontend/web/js/googlepay/button.js
+++ b/view/frontend/web/js/googlepay/button.js
@@ -78,6 +78,12 @@ define(
                             if (response.result) {
                                 button.addEventListener('click', function (event) {
                                     event.preventDefault();
+                                    
+                                    //default.js payment expects validation to be called before calling the place order chain, googlepay is not the only component in the site
+                                    if(!context.validate() || !context.getAdditionalValidators().validate()) {
+                                        return false; 
+                                    }
+                                    
                                     jQuery("body").loader('show');
                                     var responseData;
 

--- a/view/frontend/web/js/googlepay/implementations/core-checkout/method-renderer/googlepay.js
+++ b/view/frontend/web/js/googlepay/implementations/core-checkout/method-renderer/googlepay.js
@@ -5,11 +5,13 @@
 define([
     'Magento_Checkout/js/view/payment/default',
     'Magento_Checkout/js/model/quote',
-    'Magento_Braintree/js/googlepay/button'
+    'PayPal_Braintree/js/googlepay/button',
+    'Magento_Checkout/js/model/payment/additional-validators'
 ], function (
     Component,
     quote,
-    button
+    button,
+    additionalValidators
 ) {
     'use strict';
 
@@ -20,7 +22,14 @@ define([
             deviceSupported: button.deviceSupported(),
             grandTotalAmount: 0
         },
-
+        
+        /**
+         * Reveal additionalValidators to button.js component
+         */
+        getAdditionalValidators: function() {
+            return additionalValidators;
+        },
+        
         /**
          * Inject the google pay button into the target element
          */


### PR DESCRIPTION
https://github.com/genecommerce/module-braintree-magento2 

and in googlepay and applepay

https://github.com/genecommerce/module-braintree-magento2/blob/ea2e577803b16744b44c7e33e3a87bb35c8d747d/view/frontend/web/js/googlepay/button.js#L81 

validation and additionalvalidators are not called before executing call chain on click. button.js relays on context for payment object where validation is available but not additionalValidators.validate() cause this is not revealed by default  . 

default.js > placeOrder() method defines the payment method API in magento2.  before executing placeOrder chain in your own methods you must be sure that all related validators are executed. This is not so in your implementation and the result is that googlepay or applepay is started but validations are only called after when your reach placeOrder() . Now when validation fails after that you are in trouble.

The issue here is that placeOrder() forces a default API on all your payment methods and this flow should be honoured. Simply put validation needs to be called first before proceeding with any of your payment method actions

This PR does: 
* reveals additionalValidators from context. 
* utilises context.  to call validators before executing your payment method flow inside click event 

This is needed:
* cause your methods are not only methods in the page 
* other validators my exist in the page that can fail the order process 
