### PR TITLE
Added 'requires' dependency for all payment methods

### DIFF
--- a/Block/System/Config/Form/Field/RequiresStatus.php
+++ b/Block/System/Config/Form/Field/RequiresStatus.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Braintree\Block\System\Config\Form\Field;
+
+use Magento\Config\Block\System\Config\Form\Field;
+use Magento\Framework\Data\Form\Element\AbstractElement;
+
+class RequiresStatus extends Field
+{
+    /**
+     * Reset 'Requires' CSS Class
+     *
+     * @param AbstractElement $element
+     * @return string
+     */
+    public function render(AbstractElement $element)
+    {
+        if (str_contains($element->getClass(), 'braintree_ach_direct_debit_')) {
+            $requiresClass = str_replace('braintree_ach_direct_debit_', '', $element->getClass());
+            $element->setClass($requiresClass);
+        }
+        if (str_contains($element->getClass(), 'braintree_applepay_')) {
+            $requiresClass = str_replace('braintree_applepay_', '', $element->getClass());
+            $element->setClass($requiresClass);
+        }
+        if (str_contains($element->getClass(), 'braintree_local_payment_')) {
+            $requiresClass = str_replace('braintree_local_payment_', '', $element->getClass());
+            $element->setClass($requiresClass);
+        }
+
+        return parent::render($element);
+    }
+}

--- a/Block/System/Config/Form/Field/RequiresStatus.php
+++ b/Block/System/Config/Form/Field/RequiresStatus.php
@@ -30,6 +30,18 @@ class RequiresStatus extends Field
             $requiresClass = str_replace('braintree_local_payment_', '', $element->getClass());
             $element->setClass($requiresClass);
         }
+        if (str_contains($element->getClass(), 'braintree_googlepay_')) {
+            $requiresClass = str_replace('braintree_googlepay_', '', $element->getClass());
+            $element->setClass($requiresClass);
+        }
+        if (str_contains($element->getClass(), 'braintree_venmo_')) {
+            $requiresClass = str_replace('braintree_venmo_', '', $element->getClass());
+            $element->setClass($requiresClass);
+        }
+        if (str_contains($element->getClass(), 'braintree_paypal_')) {
+            $requiresClass = str_replace('braintree_paypal_', '', $element->getClass());
+            $element->setClass($requiresClass);
+        }
 
         return parent::render($element);
     }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -280,6 +280,10 @@
                             <label>Enable ACH Direct Debit</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/braintree_ach_direct_debit/active</config_path>
+                            <frontend_model>Magento\Braintree\Block\System\Config\Form\Field\RequiresStatus</frontend_model>
+                            <requires>
+                                <group id="braintree_required"/>
+                            </requires>
                         </field>
                         <field id="sort_order" translate="label" type="text" sortOrder="230" showInDefault="1" showInWebsite="1" showInStore="0">
                             <label>Sort Order</label>
@@ -309,6 +313,10 @@
                             <label>Enable ApplePay through Braintree</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/braintree_applepay/active</config_path>
+                            <frontend_model>Magento\Braintree\Block\System\Config\Form\Field\RequiresStatus</frontend_model>
+                            <requires>
+                                <group id="braintree_required"/>
+                            </requires>
                             <comment>
                                 <![CDATA[You need to <a href="https://developers.braintreepayments.com/guides/apple-pay/configuration/javascript/v3" target="_blank" rel="noopener noreferrer">verify your domain name</a> in your Braintree account first.]]>
                             </comment>
@@ -342,6 +350,10 @@
                             <label>Enable Local Payment Methods</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/braintree_local_payment/active</config_path>
+                            <frontend_model>Magento\Braintree\Block\System\Config\Form\Field\RequiresStatus</frontend_model>
+                            <requires>
+                                <group id="braintree_required"/>
+                            </requires>
                         </field>
                         <field id="title" translate="label" type="text" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="0">
                             <label>Title</label>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -389,6 +389,10 @@
                             <label>Enable GooglePay through Braintree</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/braintree_googlepay/active</config_path>
+                            <frontend_model>Magento\Braintree\Block\System\Config\Form\Field\RequiresStatus</frontend_model>
+                            <requires>
+                                <group id="braintree_required"/>
+                            </requires>
                             <comment>
                                 <![CDATA[Consult the <A href="https://developers.braintreepayments.com/guides/google-pay/testing-go-live/javascript/v3#go-live">Braintree documentation</a> when enabling Google Pay for production.]]>
                             </comment>
@@ -438,6 +442,10 @@
                             <label>Enable Venmo through Braintree</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/braintree_venmo/active</config_path>
+                            <frontend_model>Magento\Braintree\Block\System\Config\Form\Field\RequiresStatus</frontend_model>
+                            <requires>
+                                <group id="braintree_required"/>
+                            </requires>
                         </field>
                         <field id="payment_action" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="0">
                             <label>Payment Action</label>
@@ -465,6 +473,7 @@
                             <label>Enable PayPal through Braintree</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/braintree_paypal/active</config_path>
+                            <frontend_model>Magento\Braintree\Block\System\Config\Form\Field\RequiresStatus</frontend_model>
                             <requires>
                                 <group id="braintree_required"/>
                             </requires>
@@ -474,6 +483,7 @@
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/braintree_paypal_credit/active</config_path>
                             <comment>PayPal Credit is currently only available in the United States and United Kingdom. PayPal Credit will be disabled if the selected value for the Merchant Country field is not US or UK. This field only available if Merchant Country is US or UK.</comment>
+                            <frontend_model>Magento\Braintree\Block\System\Config\Form\Field\RequiresStatus</frontend_model>
                             <requires>
                                 <group id="braintree_required"/>
                             </requires>
@@ -520,6 +530,7 @@
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/braintree_paypal_paylater/active</config_path>
                             <comment>Display pay later messaging on your site for offers like Pay in 3, which lets customers pay with 3 interest-free monthly payments. We'll show messages on your site to promote this feature for you. You may not promote pay later offers with any other content, marketing, or materials.</comment>
+                            <frontend_model>Magento\Braintree\Block\System\Config\Form\Field\RequiresStatus</frontend_model>
                             <requires>
                                 <group id="braintree_required"/>
                             </requires>

--- a/view/frontend/web/js/applepay/implementations/core-checkout/method-applepay.js
+++ b/view/frontend/web/js/applepay/implementations/core-checkout/method-applepay.js
@@ -1,14 +1,26 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 define(
-    ['uiComponent', 'Magento_Checkout/js/model/payment/renderer-list'],
-    function (Component, rendererList) {
+    [
+        'uiComponent',
+        'Magento_Checkout/js/model/payment/renderer-list'
+    ],
+    function (
+        Component,
+        rendererList
+    ) {
         'use strict';
 
-        rendererList.push(
-            {
+        let config = window.checkoutConfig.payment;
+
+        if (config['braintree_applepay'].clientToken) {
+            rendererList.push({
                 type: 'braintree_applepay',
                 component: 'Magento_Braintree/js/applepay/implementations/core-checkout/method-renderer/applepay'
-            }
-        );
+            });
+        }
 
         return Component.extend({});
     }

--- a/view/frontend/web/js/googlepay/implementations/core-checkout/method-googlepay.js
+++ b/view/frontend/web/js/googlepay/implementations/core-checkout/method-googlepay.js
@@ -1,14 +1,26 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 define(
-    ['uiComponent', 'Magento_Checkout/js/model/payment/renderer-list'],
-    function (Component, rendererList) {
+    [
+        'uiComponent',
+        'Magento_Checkout/js/model/payment/renderer-list'
+    ],
+    function (
+        Component,
+        rendererList
+    ) {
         'use strict';
 
-        rendererList.push(
-            {
+        let config = window.checkoutConfig.payment;
+
+        if (config['braintree_googlepay'].clientToken) {
+            rendererList.push({
                 type: 'braintree_googlepay',
                 component: 'Magento_Braintree/js/googlepay/implementations/core-checkout/method-renderer/googlepay'
-            }
-        );
+            });
+        }
 
         return Component.extend({});
     }

--- a/view/frontend/web/js/view/payment/braintree.js
+++ b/view/frontend/web/js/view/payment/braintree.js
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 /*browser:true*/
@@ -17,40 +17,45 @@ define(
 
         let config = window.checkoutConfig.payment,
             braintreeType = 'braintree',
-            payPalType = 'braintree_paypal';
+            payPalType = 'braintree_paypal',
+            braintreeAchDirectDebit = 'braintree_ach_direct_debit',
+            braintreeVenmo = 'braintree_venmo',
+            braintreeLocalPayment = 'braintree_local_payment';
 
-        if (config[braintreeType].isActive) {
-            rendererList.push(
-                {
-                    type: braintreeType,
-                    component: 'Magento_Braintree/js/view/payment/method-renderer/hosted-fields'
-                }
-            );
+        if (config[braintreeType] && config[braintreeType].isActive && config[braintreeType].clientToken) {
+            rendererList.push({
+                type: braintreeType,
+                component: 'Magento_Braintree/js/view/payment/method-renderer/hosted-fields'
+            });
         }
 
-        if (config[payPalType].isActive) {
-            rendererList.push(
-                {
-                    type: payPalType,
-                    component: 'Magento_Braintree/js/view/payment/method-renderer/paypal'
-                }
-            );
+        if (config[payPalType] && config[payPalType].isActive) {
+            rendererList.push({
+                type: payPalType,
+                component: 'Magento_Braintree/js/view/payment/method-renderer/paypal'
+            });
         }
 
-        rendererList.push(
-            {
-                type: 'braintree_venmo',
+        if (config[braintreeVenmo] && config[braintreeVenmo].isAllowed && config[braintreeVenmo].clientToken) {
+            rendererList.push({
+                type: braintreeVenmo,
                 component: 'Magento_Braintree/js/view/payment/method-renderer/venmo'
-            },
-            {
-                type: 'braintree_ach_direct_debit',
+            });
+        }
+
+        if (config[braintreeAchDirectDebit] && config[braintreeAchDirectDebit].isActive && config[braintreeAchDirectDebit].clientToken) {
+            rendererList.push({
+                type: braintreeAchDirectDebit,
                 component: 'Magento_Braintree/js/view/payment/method-renderer/ach'
-            },
-            {
-                type: 'braintree_local_payment',
+            });
+        }
+
+        if (config[braintreeLocalPayment] && config[braintreeLocalPayment].clientToken) {
+            rendererList.push({
+                type: braintreeLocalPayment,
                 component: 'Magento_Braintree/js/view/payment/method-renderer/lpm'
-            }
-        );
+            });
+        }
 
         /** Add view logic here if needed */
         return Component.extend({});


### PR DESCRIPTION
- Fixed Braintree payment methods are visible at front-end even if credentials haven't added issue
