### PR TITLE
Fixed Too many line items error

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -225,6 +225,11 @@
                             <comment>Be sure to Enable AVS and/or CVV in Your Braintree Account in Settings/Processing Section.</comment>
                             <config_path>payment/braintree/useccv</config_path>
                         </field>
+                        <field id="send_line_items" translate="label" type="select" sortOrder="155" showInDefault="1" showInWebsite="1" showInStore="0">
+                            <label>Send Cart Line Items</label>
+                            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                            <config_path>payment/braintree/send_line_items</config_path>
+                        </field>
                         <field id="cctypes" translate="label" type="multiselect" sortOrder="160" showInDefault="1" showInWebsite="1" showInStore="0">
                             <label>Credit Card Types</label>
                             <source_model>Magento\Braintree\Model\Adminhtml\Source\CcType</source_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -30,6 +30,7 @@
                 <can_deny_payment>1</can_deny_payment>
                 <cctypes>AE,VI,MC,DI,JCB,DN,MI</cctypes>
                 <useccv>1</useccv>
+                <send_line_items>1</send_line_items>
                 <cctypes_braintree_mapper><![CDATA[{"american-express":"AE","discover":"DI","jcb":"JCB","mastercard":"MC","master-card":"MC","visa":"VI","maestro":"MI","uk-maestro":"MI","diners-club":"DN"}]]></cctypes_braintree_mapper>
                 <order_status>processing</order_status>
                 <environment>sandbox</environment>


### PR DESCRIPTION
- Fixed too many items error
- Added new configuration field called **Send Line Items** as **Yes/No**.
- Line items will only be submitted to the braintreee if it is enabled from the admin panel and Line item is less than 250.