### PR TITLE
Update config.xml

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -176,7 +176,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_authorize>1</can_authorize>
                 <can_capture>1</can_capture>
-                <can_capture_partial>0</can_capture_partial>
+                <can_capture_partial>1</can_capture_partial>
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_void>1</can_void>


### PR DESCRIPTION
This can be enabled and does work. 

We usually patch this but I'm tired of reformatting the patch every release.

I have no idea why you've now enabled `can_refund_partial_per_invoice` but not `can_capture_partial` - how are you going to refund something that can't be captured? 😂