### PR TITLE
Reconfigure PayPal PayLater Message syntax

### DIFF
--- a/Gateway/Config/PayPalPayLater/Config.php
+++ b/Gateway/Config/PayPalPayLater/Config.php
@@ -123,8 +123,8 @@ class Config implements ConfigInterface
         $paypalPayLaterMessageActive = $this->getConfigValue(
             "payment/braintree_paypal/button_location_" . $buttonType . "_type_messaging_show"
         );
-        // If PayPal or PayPal Pay Later is disabled in the admin
-        if (!$paypalActive || !$paypalPayLaterMessageActive || $this->isPayPalVaultActive()) {
+        // If PayPal or PayPal Pay Later Message is disabled or PayPal Vault is enabled on checkout
+        if (!$paypalActive || !$paypalPayLaterMessageActive || ($this->IsPayPalVaultActive() && $type == 'checkout')) {
             return false;
         }
 

--- a/view/frontend/templates/paypal/button.phtml
+++ b/view/frontend/templates/paypal/button.phtml
@@ -90,7 +90,7 @@ try {
                  class="action-braintree-paypal-logo"></div>
         </div>
     <?php endif; ?>
-    <?php if ($block->showPayPalButton('messaging', 'cart') && !$block->isPayPalVaultActive()): ?>
+    <?php if ($block->showPayPalButton('messaging', 'cart')): ?>
         <div class="action-braintree-paypal-message"
              id="<?= $block->escapeHtmlAttr($paypalPaylaterId) ?>-message"
              data-pp-amount="<?= $block->escapeHtmlAttr($block->getAmount()) ?>"

--- a/view/frontend/templates/paypal/product_page.phtml
+++ b/view/frontend/templates/paypal/product_page.phtml
@@ -96,7 +96,7 @@ try {
                  class="action-braintree-paypal-logo"></div>
         </div>
     <?php endif; ?>
-    <?php if ($block->showPayPalButton('messaging', 'productpage') && !$block->isPayPalVaultActive()): ?>
+    <?php if ($block->showPayPalButton('messaging', 'productpage')): ?>
         <div class="action-braintree-paypal-message"
              id="<?= $block->escapeHtmlAttr($paypalPaylaterId) ?>-message"
              data-pp-amount="<?= $block->escapeHtmlAttr($block->getAmount()) ?>"


### PR DESCRIPTION
PayPal PayLater messaging should be allowed to be displayed on cart & product page even if Vault is enabled as the Vault is not used on cart and product pages