### PR TITLE
Fix: adds a defense to avoid attempting an unserialize action on an array 

### DIFF
--- a/Gateway/Config/Config.php
+++ b/Gateway/Config/Config.php
@@ -96,7 +96,12 @@ class Config extends \Magento\Payment\Gateway\Config\Config
         if (!$countryCardTypes) {
             return [];
         }
-        $countryCardTypes = $this->serializer->unserialize($countryCardTypes);
+        if (is_array($countryCardTypes)) {
+            return $countryCardTypes;
+        }
+        if (is_string($countryCardTypes)) {
+            $countryCardTypes = $this->serializer->unserialize($countryCardTypes);
+        }
         return is_array($countryCardTypes) ? $countryCardTypes : [];
     }
 


### PR DESCRIPTION
This case happens when dumping config from magento 2 with an empty braintree config
Then $countryCardTypes is save as an empty array in app/etc/config.php (and not a string of an empty array)
Magento 2 Import config does not fails 
But when the framework try to read the config (when users access the cart page) then an unserialize is attempted which leads to an Exception

