### PR TITLE
[Warning Fix] Addition of single quote around unsafe_inline to avoid it being considered as url.

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -28,7 +28,7 @@
         </policy>
         <policy id="style-src">
             <values>
-                <value id="unsafe_inline" type="host">unsafe-inline</value>
+                <value id="unsafe_inline" type="host">'unsafe-inline'</value>
                 <value id="assets_braintree_style" type="host">assets.braintreegateway.com</value>
             </values>
         </policy>


### PR DESCRIPTION
Hello,

I encountered this warning on Mozilla Firefox. The console warning is just spammed with the same message (Magento 2.4.5).
Here the message on a french browser :
Content Security Policy: https://unsafe-inline/ a été interprété comme un nom d’hôte et non comme un mot-clé. S’il s’agissait vraiment d’un mot-clé, utilisez 'unsafe-inline' (entouré d’apostrophes)

Basically, it reports that unsafe-inline without single quote is considered as host name.
Adding those single quotes remove the message in the console.

Regards,