### PR TITLE
Fix show loader on checkout page on failed response from google pay

### DIFF
--- a/view/frontend/web/js/googlepay/button.js
+++ b/view/frontend/web/js/googlepay/button.js
@@ -124,6 +124,7 @@ define(
                                                 return googlePaymentInstance.parseResponse(paymentData);
                                             }).then(function (result) {
                                                 context.startPlaceOrder(result.nonce, responseData, dataCollectorInstance.deviceData);
+                                                jQuery("body").loader('hide');
                                             }).catch(function (err) {
                                                 // Handle errors
                                                 // err = {statusCode: "CANCELED"}


### PR DESCRIPTION
## Reproducible steps:

1. Place an order with an amount between 2000.00 - 2999.99 to get failed transaction
2. Google pay popup closed and show an error message on checkout page

## Current behavior

Display loader on the checkout page on failure payment. The user can't do anything on the checkout page.

## Excepted Behaviour

The loader should be hidden on payment failure.

