### PR TITLE
Remove unsafe-inline as a host in CSP style-src policy

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -28,7 +28,6 @@
         </policy>
         <policy id="style-src">
             <values>
-                <value id="unsafe_inline" type="host">unsafe-inline</value>
                 <value id="assets_braintree_style" type="host">assets.braintreegateway.com</value>
             </values>
         </policy>


### PR DESCRIPTION
Remove "unsafe-inline" as a host in CSP whitelist config.

It does add a `unsafe-inline` string in the `Content-Security-Policy` HTTP header which is not valid.

The real `unsafe-inline` directive is already handled in the `magento/module-csp/etc/config.xml` file:

```xml
<styles>
    <policy_id>style-src</policy_id>
    <self>1</self>
    <inline>1</inline>
    <eval>0</eval>
    <dynamic>0</dynamic>
</styles>
```